### PR TITLE
Added API call to retrieve activation bytes from www.audible.com

### DIFF
--- a/AudibleApi/Api.Activation.cs
+++ b/AudibleApi/Api.Activation.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AudibleApi
+{
+    public partial class Api
+    {
+        static Api()
+        {
+            //Device license response encoded in ISO-8859-15. Register encoding providers once. 
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+        const int ACTIVATION_BLOB_SZ = 0x238;
+        public async Task<string> GetActivationBytesAsync()
+        {
+            // note: this call uses the audible login uri, NOT api
+            var client = Sharer.GetSharedHttpClient(_locale.AudibleLoginUri());
+
+            var response = await AdHocAuthenticatedGetAsync($"/license/token?action=register&player_manuf=Audible,iPhone&player_model=iPhone", client);
+
+            var deviceLicense = await response.Content.ReadAsByteArrayAsync();
+
+            if (deviceLicense.Length < ACTIVATION_BLOB_SZ)
+                throw new ApiErrorException(response.Headers.Location, new JObject { { "error", "Unexpected activation response: " + await response.Content.ReadAsStringAsync() } });
+
+            //activation bytes are at beginning of activation blob
+            uint actBytes = BitConverter.ToUInt32(deviceLicense, deviceLicense.Length - ACTIVATION_BLOB_SZ);
+
+            return actBytes.ToString("x8");
+        }
+    }
+}

--- a/AudibleApi/Api.Library.cs
+++ b/AudibleApi/Api.Library.cs
@@ -253,6 +253,35 @@ namespace AudibleApi
 		}
 		#endregion
 
+		#region GetLibraryBookChapters
+		public async Task<AudibleApiDTOs.ContentMetadata> GetLibraryBookMetadataAsync(string asin)
+		{
+			if (asin is null)
+				throw new ArgumentNullException(nameof(asin));
+			if (string.IsNullOrWhiteSpace(asin))
+				throw new ArgumentException("asin may not be blank", nameof(asin));
+
+			asin = asin.ToUpper().Trim();
+
+			var url = $"{CONTENT_PATH}/{asin}/metadata?response_groups=chapter_info,content_reference";
+			var response = await AdHocAuthenticatedGetAsync(url);
+			var bookJObj = await response.Content.ReadAsJObjectAsync();
+			var metadataJson = bookJObj.ToString();
+
+			AudibleApiDTOs.MetadataDtoV10 contentMetadata;
+			try
+			{
+				contentMetadata = AudibleApiDTOs.MetadataDtoV10.FromJson(metadataJson);
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Logger.Error(ex, $"Error retrieving content metadata for asin: {asin}");
+				throw;
+			}
+			return contentMetadata?.ContentMetadata;
+		}
+		#endregion
+
 		#region GetAllLibraryItemsAsync
 		public async Task<List<AudibleApiDTOs.Item>> GetAllLibraryItemsAsync()
 		{

--- a/AudibleApi/Resources.cs
+++ b/AudibleApi/Resources.cs
@@ -10,6 +10,9 @@ namespace AudibleApi
 		private static string _audibleApiUrl(this Locale locale) => $"https://api.audible.{locale.TopDomain}";
 		public static Uri AudibleApiUri(this Locale locale) => new Uri(locale._audibleApiUrl());
 
+		private static string _audibleLoginUrl(this Locale locale) => $"https://www.audible.{locale.TopDomain}";
+		public static Uri AudibleLoginUri(this Locale locale) => new Uri(locale._audibleLoginUrl());
+
 		private static string _amazonApiUrl(this Locale locale) => $"https://api.amazon.{locale.TopDomain}";
 		public static Uri AmazonApiUri(this Locale locale) => new Uri(locale._amazonApiUrl());
 

--- a/AudibleApiDTOs/MetadataDtoV10.cs
+++ b/AudibleApiDTOs/MetadataDtoV10.cs
@@ -1,0 +1,100 @@
+﻿using Newtonsoft.Json;
+using System.Text;
+
+namespace AudibleApiDTOs
+{
+    public partial class MetadataDtoV10
+    {
+        [JsonProperty("content_metadata")]
+        public ContentMetadata ContentMetadata { get; set; }
+
+        [JsonProperty("response_groups")]
+        public string[] ResponseGroups { get; set; }
+    }
+
+    public partial class ContentMetadata
+    {
+        [JsonProperty("chapter_info")]
+        public ChapterInfo ChapterInfo { get; set; }
+
+        [JsonProperty("content_reference")]
+        public ContentReference ContentReference { get; set; }
+    }
+
+    public partial class ChapterInfo
+    {
+        [JsonProperty("brandIntroDurationMs")]
+        public long BrandIntroDurationMs { get; set; }
+
+        [JsonProperty("brandOutroDurationMs")]
+        public long BrandOutroDurationMs { get; set; }
+
+        [JsonProperty("chapters")]
+        public Chapter[] Chapters { get; set; }
+
+        [JsonProperty("is_accurate")]
+        public bool IsAccurate { get; set; }
+
+        [JsonProperty("runtime_length_ms")]
+        public long RuntimeLengthMs { get; set; }
+
+        [JsonProperty("runtime_length_sec")]
+        public long RuntimeLengthSec { get; set; }
+    }
+
+    public partial class Chapter
+    {
+        [JsonProperty("length_ms")]
+        public long LengthMs { get; set; }
+
+        [JsonProperty("start_offset_ms")]
+        public long StartOffsetMs { get; set; }
+
+        [JsonProperty("start_offset_sec")]
+        public long StartOffsetSec { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+    }
+
+    public partial class ContentReference
+    {
+        [JsonProperty("acr")]
+        public string Acr { get; set; }
+
+        [JsonProperty("asin")]
+        public string Asin { get; set; }
+
+        [JsonProperty("content_format")]
+        public string ContentFormat { get; set; }
+
+        [JsonProperty("content_size_in_bytes")]
+        public long ContentSizeInBytes { get; set; }
+
+        [JsonProperty("file_version")]
+        [JsonConverter(typeof(ParseStringConverter))]
+        public long FileVersion { get; set; }
+
+        [JsonProperty("marketplace")]
+        public string Marketplace { get; set; }
+
+        [JsonProperty("sku")]
+        public string Sku { get; set; }
+
+        [JsonProperty("tempo")]
+        public string Tempo { get; set; }
+
+        [JsonProperty("version")]
+        [JsonConverter(typeof(ParseStringConverter))]
+        public long Version { get; set; }
+    }
+
+    public partial class MetadataDtoV10
+    {
+        public static MetadataDtoV10 FromJson(string json) => JsonConvert.DeserializeObject<MetadataDtoV10>(json, AudibleApiDTOs.Converter.Settings);
+    }
+    public static partial class Serialize
+    {
+        public static string ToJson(this MetadataDtoV10 self) => JsonConvert.SerializeObject(self, AudibleApiDTOs.Converter.Settings);
+    }
+}


### PR DESCRIPTION
I added an API call to retrieve decryption key from the server. This should obviate need for rcrack and decrease the package by over 50MB.

I also added an API call to retrieve content metadata. The metadata includes ChapterInfo which contains all chapter offsets and names, and differs from the chapter info in the aax tags. I made use of this in my Libation modifications.