### PR TITLE
Add support for AAXC

### DIFF
--- a/AudibleApi/Authorization/Authorize.cs
+++ b/AudibleApi/Authorization/Authorize.cs
@@ -73,9 +73,8 @@ namespace AudibleApi.Authorization
 
 				response.EnsureSuccessStatusCode();
 
-				var postResponseBody = await response.Content.ReadAsStringAsync();
-				var jObj = JObject.Parse(postResponseBody);
-				return jObj;
+				var postResponseJObj = await response.Content.ReadAsJObjectAsync();
+				return postResponseJObj;
 			}
 			catch (Exception ex)
 			{

--- a/AudibleApi/Authorization/IIdentity.cs
+++ b/AudibleApi/Authorization/IIdentity.cs
@@ -24,9 +24,15 @@ namespace AudibleApi.Authorization
 
         IEnumerable<KVP<string, string>> Cookies { get; }
 
-		void Update(AccessToken accessToken);
+        string DeviceSerialNumber { get; }
 
-		void Update(PrivateKey privateKey, AdpToken adpToken, AccessToken accessToken, RefreshToken refreshToken);
+        string DeviceType { get; }
+
+        string AmazonAccountId { get; }
+
+        void Update(AccessToken accessToken);
+
+		void Update(PrivateKey privateKey, AdpToken adpToken, AccessToken accessToken, RefreshToken refreshToken, string deviceSN = null, string deviceType = null, string amazonAccountId = null);
 
 		void Invalidate();
 	}

--- a/AudibleApi/Authorization/IIdentityMaintainer.cs
+++ b/AudibleApi/Authorization/IIdentityMaintainer.cs
@@ -11,7 +11,9 @@ namespace AudibleApi.Authorization
 	{
 		ISystemDateTime SystemDateTime { get; }
 		Locale Locale { get; }
-
+		string DeviceSerialNumber { get; }
+		string DeviceType { get; }
+		string AmazonAccountId { get; }
 		Task<AccessToken> GetAccessTokenAsync();
 		Task<AdpToken> GetAdpTokenAsync();
 		Task<PrivateKey> GetPrivateKeyAsync();

--- a/AudibleApi/Authorization/Identity [partial].cs
+++ b/AudibleApi/Authorization/Identity [partial].cs
@@ -36,10 +36,13 @@ namespace AudibleApi.Authorization
         protected List<KVP<string, string>> _cookies { private get; set; }
         public IEnumerable<KVP<string, string>> Cookies => _cookies.AsReadOnly();
 
+		[JsonProperty]
 		public string DeviceSerialNumber { get; private set; }
 
+		[JsonProperty]
 		public string DeviceType { get; private set; }
 
+		[JsonProperty]
 		public string AmazonAccountId { get; private set; }
 
 		protected Identity() { }

--- a/AudibleApi/Authorization/Identity [partial].cs
+++ b/AudibleApi/Authorization/Identity [partial].cs
@@ -36,6 +36,12 @@ namespace AudibleApi.Authorization
         protected List<KVP<string, string>> _cookies { private get; set; }
         public IEnumerable<KVP<string, string>> Cookies => _cookies.AsReadOnly();
 
+		public string DeviceSerialNumber { get; private set; }
+
+		public string DeviceType { get; private set; }
+
+		public string AmazonAccountId { get; private set; }
+
 		protected Identity() { }
 
 		public Identity(Locale locale)
@@ -64,7 +70,7 @@ namespace AudibleApi.Authorization
 			Updated?.Invoke(this, new EventArgs());
 		}
 
-		public void Update(PrivateKey privateKey, AdpToken adpToken, AccessToken accessToken, RefreshToken refreshToken)
+		public void Update(PrivateKey privateKey, AdpToken adpToken, AccessToken accessToken, RefreshToken refreshToken, string deviceSN = null, string deviceType = null, string amazonAccountId = null)
 		{
 			if (privateKey is null)
 				throw new ArgumentNullException(nameof(privateKey));
@@ -79,6 +85,10 @@ namespace AudibleApi.Authorization
 			AdpToken = new AdpToken(adpToken);
 			ExistingAccessToken = accessToken;
 			RefreshToken = new RefreshToken(refreshToken);
+
+			DeviceSerialNumber = deviceSN ?? string.Empty;
+			DeviceType = deviceType ?? string.Empty;
+			AmazonAccountId = amazonAccountId ?? string.Empty;
 
 			Updated?.Invoke(this, new EventArgs());
 
@@ -95,5 +105,5 @@ namespace AudibleApi.Authorization
 
 			IsValid = false;
 		}
-	}
+    }
 }

--- a/AudibleApi/Authorization/IdentityMaintainer.cs
+++ b/AudibleApi/Authorization/IdentityMaintainer.cs
@@ -15,6 +15,12 @@ namespace AudibleApi.Authorization
 		private IIdentity _identity { get; }
 		private IAuthorize _authorize { get; }
 
+		public string DeviceSerialNumber => _identity.DeviceSerialNumber;
+
+		public string DeviceType => _identity.DeviceType;
+
+		public string AmazonAccountId => _identity.AmazonAccountId;
+
 		public static async Task<IdentityMaintainer> CreateAsync(IIdentity identity)
 		{
 			StackBlocker.ApiTestBlocker();

--- a/AudibleApi/Authorization/RegistrationParser.cs
+++ b/AudibleApi/Authorization/RegistrationParser.cs
@@ -15,6 +15,12 @@ namespace AudibleApi.Authorization
 			if (systemDateTime is null)
 				throw new ArgumentNullException(nameof(systemDateTime));
 
+			var extensions = authRegister["response"]["success"]["extensions"];
+
+			var deviceSN = extensions["device_info"]["device_serial_number"].ToString();
+			var deviceType = extensions["device_info"]["device_type"].ToString();
+			var amazonAccountId = extensions["customer_info"]["user_id"].ToString();
+
 			var tokens = authRegister["response"]["success"]["tokens"];
 
 			var privateKey = tokens["mac_dms"]["device_private_key"].ToString();
@@ -29,7 +35,10 @@ namespace AudibleApi.Authorization
 				new PrivateKey(privateKey),
 				new AdpToken(adpToken),
 				new AccessToken(accessToken, expiresDateTime),
-				new RefreshToken(refreshToken)
+				new RefreshToken(refreshToken),
+				deviceSN,
+				deviceType,
+				amazonAccountId
 				);
 		}
 	}


### PR DESCRIPTION
Add device_type, device_serial_number, and user_id to Identity. These three fields are used to decrypt the AACX license and persist with the activation.

Add code to decrypt license_response to retrieve audible_key and audible_iv. Code from https://patchwork.ffmpeg.org/project/ffmpeg/patch/17559601585196510@sas2-2fa759678732.qloud-c.yandex.net