### PR TITLE
Ensure device information and amazon account ID are in Identity.

### DIFF
--- a/AudibleApi/Authorization/IdentityMaintainer.cs
+++ b/AudibleApi/Authorization/IdentityMaintainer.cs
@@ -74,6 +74,14 @@ namespace AudibleApi.Authorization
 			try
 			{
 				await RefreshAccessTokenAsync();
+
+				if (string.IsNullOrWhiteSpace(DeviceType)
+				|| string.IsNullOrWhiteSpace(DeviceSerialNumber)
+				|| string.IsNullOrWhiteSpace(AmazonAccountId))
+				{
+					await DeregisterAsync();
+					await RegisterAsync();
+				}
 			}
 			catch
 			{


### PR DESCRIPTION
If any of DeviceSerialNumber, DeviceType, or AmazonAccountId are null or empty, IdentityMaintainer will reauthorize to get those values and add them to Identity.