### PR TITLE
Changed Episode detection and improved error handling and logging in GetDownloadLicenseAsync()

### DIFF
--- a/AudibleApi/Api.Download.cs
+++ b/AudibleApi/Api.Download.cs
@@ -103,8 +103,6 @@ namespace AudibleApi
                 throw apiExp;
             }
 
-            // if we get "message" on this level means something went wrong.
-            // "message" should be nested under "ContentLicense"
             if (contentLicenseDtoV10?.Message is not null)
             {
                 var ex = new InvalidResponseException(

--- a/AudibleApi/Api.Download.cs
+++ b/AudibleApi/Api.Download.cs
@@ -1,177 +1,176 @@
-﻿using System;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
-using AudibleApiDTOs;
+﻿using AudibleApiDTOs;
 using Dinah.Core;
 using Dinah.Core.Net.Http;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace AudibleApi
 {
-	public enum DownloadQuality
+    public enum DownloadQuality
     {
-		Extreme,
-		High,
-		Normal,
-		Low
-	}
+        Extreme,
+        High,
+        Normal,
+        Low
+    }
     public partial class Api
     {
         const string CONTENT_PATH = "/1.0/content";
 
-		#region Download License
+        #region Download License
 
-		/// <summary>
-		/// Requests a license to download Audible content.
-		/// </summary>
-		/// <param name="asin">Audible Asin of book</param>
-		/// <param name="quality">Desired audio Quality</param>
-		/// <returns>a valid <see cref="ContentLicense"/> containing content_reference, chapter_info, and pdf_url.</returns>
-		/// <exception cref="ApiErrorException">Thrown when the Api request failed.</exception>
-		/// <exception cref="InvalidResponseException">Thrown when the Api did not return a proper <see cref="ContentLicense"/>.</exception>
-		/// <exception cref="InvalidValueException">Thrown when <see cref="ContentLicense.StatusCode"/> is not "Granted" or "Denied".</exception>
-		/// <exception cref="ValidationErrorException">Thrown when <see cref="ContentLicense.StatusCode"/> is "Denied".</exception>
-		public async Task<ContentLicense> GetDownloadLicenseAsync(string asin, DownloadQuality quality = DownloadQuality.Extreme)
-		{
-			ArgumentValidator.EnsureNotNullOrWhiteSpace(asin, nameof(asin));
+        /// <summary>
+        /// Requests a license to download Audible content.
+        /// </summary>
+        /// <param name="asin">Audible Asin of book</param>
+        /// <param name="quality">Desired audio Quality</param>
+        /// <returns>a valid <see cref="ContentLicense"/> containing content_reference, chapter_info, and pdf_url.</returns>
+        /// <exception cref="ApiErrorException">Thrown when the Api request failed.</exception>
+        /// <exception cref="InvalidResponseException">Thrown when the Api did not return a proper <see cref="ContentLicense"/>.</exception>
+        /// <exception cref="InvalidValueException">Thrown when <see cref="ContentLicense.StatusCode"/> is not "Granted" or "Denied".</exception>
+        /// <exception cref="ValidationErrorException">Thrown when <see cref="ContentLicense.StatusCode"/> is "Denied".</exception>
+        public async Task<ContentLicense> GetDownloadLicenseAsync(string asin, DownloadQuality quality = DownloadQuality.Extreme)
+        {
+            ArgumentValidator.EnsureNotNullOrWhiteSpace(asin, nameof(asin));
 
-			var body = new JObject
-			{
-				{ "consumption_type", "Download" },
-				{ "drm_type", "Adrm" },
-				{ "quality", quality.ToString() },
-				{ "response_groups", "last_position_heard,pdf_url,content_reference,chapter_info"}
-			};
-			var url = $"{CONTENT_PATH}/{asin}/licenserequest";
-
-			var request = new HttpRequestMessage(HttpMethod.Post, url);
-			request.AddContent(body);
-			await signRequestAsync(request);
-
-			HttpResponseMessage response;
-			try
-			{
-				response = await _client.SendAsync(request);
-			}
-			catch (ApiErrorException ex)
-			{
-				//Assume this exception will not contain PII.
-				ex.LogException(Serilog.Log.Logger.Error);
-				throw;
-			}
-			catch (Exception ex)
-			{
-				var apiExp = new ApiErrorException(
-					request.RequestUri,
-					body,
-					$"Error requesting license for asin: [{asin}]",
-					ex);
-
-				apiExp.LogException(Serilog.Log.Logger.Error);
-				throw apiExp;
-			}
-
-			if (response.StatusCode != HttpStatusCode.OK)
+            var body = new JObject
             {
-				var ex = new ApiErrorException(
-					response.Headers.Location,
-					//Assume this response does not contain PII.
-					new JObject { { "http_response_code", response.StatusCode.ToString() }, { "response", await response.Content.ReadAsStringAsync() } },
-					$"License response not \"OK\" for asin: [{asin}]");
+                { "consumption_type", "Download" },
+                { "drm_type", "Adrm" },
+                { "quality", quality.ToString() },
+                { "response_groups", "last_position_heard,pdf_url,content_reference,chapter_info"}
+            };
+            var url = $"{CONTENT_PATH}/{asin}/licenserequest";
 
-				ex.LogException(Serilog.Log.Logger.Error);
-				throw ex;
-			}
+            var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.AddContent(body);
+            await signRequestAsync(request);
 
-			var responseJobj = await response.Content.ReadAsJObjectAsync();
-
-			// if we get "message" on this level means something went wrong.
-			// "message" should be nested under "content_license"
-			if (responseJobj.TryGetValue("message", out var val))
-			{
-				var responseMessage = val.Value<string>();
-				var ex = new InvalidResponseException(
-					response.Headers.Location,
-					new JObject { { "message", responseMessage } }, //Assume this message does not contain PII.
-					$"License response returned error for asin: [{asin}]");
-
-				ex.LogException(Serilog.Log.Logger.Error);
-				throw ex;
-			}
-
-			ContentLicenseDtoV10 contentLicenseDtoV10;
-			try
-			{
-				contentLicenseDtoV10 = ContentLicenseDtoV10.FromJson(responseJobj, _identityMaintainer.DeviceType, _identityMaintainer.DeviceSerialNumber, _identityMaintainer.AmazonAccountId);
-			}
-			catch (Exception ex)
-			{
-				var apiExp = new InvalidResponseException(
-					   response.Headers.Location,
-					   responseJobj, //Even if the object doesn't parse, it may contain PII.
-					   $"License response could not be parsed for asin: [{asin}]",
-					   ex);
-
-				apiExp.LogException(Serilog.Log.Logger.Verbose);
-				throw apiExp;
-			}
-
-			if (contentLicenseDtoV10?.ContentLicense?.StatusCode is null)
-			{
-				var ex = new InvalidValueException(
-					response.Headers.Location,
-					responseJobj, //This error shouldn't happen, so log the entire response which contains PII.
-					$"License response does not contain a valid status code for asin: [{asin}]");
-
-				ex.LogException(Serilog.Log.Logger.Verbose);
-				throw ex;
-			}
-
-			if (contentLicenseDtoV10.ContentLicense.StatusCode.EqualsInsensitive("Denied"))
+            HttpResponseMessage response;
+            try
             {
-				var ex = new ValidationErrorException(
-					response.Headers.Location,
-					//Denial reasons may contain PII.
-					new JObject { { "license_denial_reasons", JArray.FromObject(contentLicenseDtoV10.ContentLicense.LicenseDenialReasons) } },
-					$"Content License denied for asin: [{asin}]");
+                response = await _client.SendAsync(request);
+            }
+            catch (ApiErrorException ex)
+            {
+                //Assume this exception will not contain PII.
+                ex.LogException(Serilog.Log.Logger.Error);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                var apiExp = new ApiErrorException(
+                    request.RequestUri,
+                    body,
+                    $"Error requesting license for asin: [{asin}]",
+                    ex);
 
-				ex.LogException(Serilog.Log.Logger.Verbose);
-				throw ex;
-			}
-
-			if (!contentLicenseDtoV10.ContentLicense.StatusCode.EqualsInsensitive("Granted"))
-			{
-				var ex = new InvalidValueException(
-					response.Headers.Location,
-					responseJobj, //This error shouldn't happen, so log the entire response which contains PII.
-					$"Unrecognized status code \"{contentLicenseDtoV10.ContentLicense.StatusCode}\" for asin: [{asin}]");
-
-				ex.LogException(Serilog.Log.Logger.Verbose);
-				throw ex;
+                apiExp.LogException(Serilog.Log.Logger.Error);
+                throw apiExp;
             }
 
-			return contentLicenseDtoV10.ContentLicense;
-		}
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                var ex = new ApiErrorException(
+                    response.Headers.Location,
+                    //Assume this response does not contain PII.
+                    new JObject { { "http_response_code", response.StatusCode.ToString() }, { "response", await response.Content.ReadAsStringAsync() } },
+                    $"License response not \"OK\" for asin: [{asin}]");
 
-		#endregion
+                ex.LogException(Serilog.Log.Logger.Error);
+                throw ex;
+            }
 
-		public async Task<string> GetPdfDownloadLinkAsync(string asin)
-		{
-			//// SEPT 2020:
+            var responseJobj = await response.Content.ReadAsJObjectAsync();
 
-			//// no longer works. This url now returns 403
-			// var downloadUrl = libraryBook?.Book?.Supplements?.FirstOrDefault()?.Url;
+            // if we get "message" on this level means something went wrong.
+            // "message" should be nested under "content_license"
+            if (responseJobj.TryGetValue("message", out var val))
+            {
+                var responseMessage = val.Value<string>();
+                var ex = new InvalidResponseException(
+                    response.Headers.Location,
+                    new JObject { { "message", responseMessage } }, //Assume this message does not contain PII.
+                    $"License response returned error for asin: [{asin}]");
 
-			//// this works for now:
-			// MUST use relative url here
-			var request = new HttpRequestMessage(HttpMethod.Head, $"/companion-file/{asin}");
-			var client = Sharer.GetSharedHttpClient($"https://www.audible.{_locale.TopDomain}");
-			var response = await AdHocAuthenticatedGetAsync(request, client);
+                ex.LogException(Serilog.Log.Logger.Error);
+                throw ex;
+            }
 
-			var downloadUrl = response.Headers.Location.AbsoluteUri;
-			return downloadUrl;
-		}
-	}
+            ContentLicenseDtoV10 contentLicenseDtoV10;
+            try
+            {
+                contentLicenseDtoV10 = ContentLicenseDtoV10.FromJson(responseJobj, _identityMaintainer.DeviceType, _identityMaintainer.DeviceSerialNumber, _identityMaintainer.AmazonAccountId);
+            }
+            catch (Exception ex)
+            {
+                var apiExp = new InvalidResponseException(
+                       response.Headers.Location,
+                       responseJobj, //Even if the object doesn't parse, it may contain PII.
+                       $"License response could not be parsed for asin: [{asin}]",
+                       ex);
+
+                apiExp.LogException(Serilog.Log.Logger.Verbose);
+                throw apiExp;
+            }
+
+            if (contentLicenseDtoV10?.ContentLicense?.StatusCode is null)
+            {
+                var ex = new InvalidValueException(
+                    response.Headers.Location,
+                    responseJobj, //This error shouldn't happen, so log the entire response which contains PII.
+                    $"License response does not contain a valid status code for asin: [{asin}]");
+
+                ex.LogException(Serilog.Log.Logger.Verbose);
+                throw ex;
+            }
+
+            if (contentLicenseDtoV10.ContentLicense.StatusCode.EqualsInsensitive("Denied"))
+            {
+                var ex = new ValidationErrorException(
+                    response.Headers.Location,
+                    //Denial reasons may contain PII.
+                    new JObject { { "license_denial_reasons", JArray.FromObject(contentLicenseDtoV10.ContentLicense.LicenseDenialReasons) } },
+                    $"Content License denied for asin: [{asin}]");
+
+                ex.LogException(Serilog.Log.Logger.Verbose);
+                throw ex;
+            }
+
+            if (!contentLicenseDtoV10.ContentLicense.StatusCode.EqualsInsensitive("Granted"))
+            {
+                var ex = new InvalidValueException(
+                    response.Headers.Location,
+                    responseJobj, //This error shouldn't happen, so log the entire response which contains PII.
+                    $"Unrecognized status code \"{contentLicenseDtoV10.ContentLicense.StatusCode}\" for asin: [{asin}]");
+
+                ex.LogException(Serilog.Log.Logger.Verbose);
+                throw ex;
+            }
+
+            return contentLicenseDtoV10.ContentLicense;
+        }
+
+        #endregion
+
+        public async Task<string> GetPdfDownloadLinkAsync(string asin)
+        {
+            //// SEPT 2020:
+
+            //// no longer works. This url now returns 403
+            // var downloadUrl = libraryBook?.Book?.Supplements?.FirstOrDefault()?.Url;
+
+            //// this works for now:
+            // MUST use relative url here
+            var request = new HttpRequestMessage(HttpMethod.Head, $"/companion-file/{asin}");
+            var client = Sharer.GetSharedHttpClient($"https://www.audible.{_locale.TopDomain}");
+            var response = await AdHocAuthenticatedGetAsync(request, client);
+
+            var downloadUrl = response.Headers.Location.AbsoluteUri;
+            return downloadUrl;
+        }
+    }
 }

--- a/AudibleApi/ApiExceptions/AudibleApiException.cs
+++ b/AudibleApi/ApiExceptions/AudibleApiException.cs
@@ -17,5 +17,7 @@ namespace AudibleApi
             RequestUri = requestUri;
             JsonMessage = jsonMessage;
         }
+        public void LogException(Action<Exception, string, string> logMethod)
+            => logMethod(this, $"{Message} {{@DebugInfo}}", JsonMessage.ToString(Newtonsoft.Json.Formatting.None));
     }
 }

--- a/AudibleApi/Asn1Value.cs
+++ b/AudibleApi/Asn1Value.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Formats.Asn1;
+
+namespace AudibleApi
+{
+     /// <summary>
+     /// Represents an Asn.1 encoded value
+     /// </summary>
+    internal class Asn1Value
+    {
+        public Asn1Tag Type { get; private set; }
+        public byte[] Value { get; private set; }
+        public List<Asn1Value> Children { get; private set; }
+
+        public override string ToString() => $"{nameof(Asn1Value)} ({Type})";
+        public static Asn1Value Parse(byte[] bytes) => ParseInternal(bytes, out _);
+
+        /// <summary>
+        /// Recursively parse an Asn.1 object.
+        /// </summary>
+        private static Asn1Value ParseInternal(byte[] bytes, out int bytesConsumed)
+        {
+            var type = AsnDecoder.ReadEncodedValue(bytes, AsnEncodingRules.BER, out int contentOffset, out int contentLength, out bytesConsumed);
+
+            var asn1Value = new Asn1Value
+            {
+                Type = type
+            };
+
+            byte[] content = new byte[contentLength];
+            Buffer.BlockCopy(bytes, contentOffset, content, 0, contentLength);
+
+            if (type == Asn1Tag.Sequence ||
+                type == Asn1Tag.SetOf)
+            {
+                asn1Value.Children = new List<Asn1Value>();
+
+                int consumedLength = 0;
+
+                while (consumedLength < contentLength)
+                {
+                    var subVal = ParseInternal(content, out int subLength);
+                    consumedLength += subLength;
+                    asn1Value.Children.Add(subVal);
+
+                    //Move all subsequent Asn.1 values to the front of the content buffer.
+                    Buffer.BlockCopy(content, subLength, content, 0, contentLength - consumedLength);
+                }
+            }
+            else
+            {
+                asn1Value.Value = content;
+            }
+
+            return asn1Value;
+        }
+    }
+}

--- a/AudibleApi/Cryptography.cs
+++ b/AudibleApi/Cryptography.cs
@@ -110,7 +110,7 @@ namespace AudibleApi
             var RSAparams = new RSAParameters();
 
             //Guess the key size based on modulus size. Assume key size is multiple of 128 bits.
-            int keySizeGuess = (int)Math.Round(keySequence.Children[1].Value.Length / 16d, 0) * 128;
+            int keySizeGuess = (int)Math.Round(keySequence.Children[1].Value.Length / 4d, 0) * 32;
 
             RSAparams.Modulus = ValidateInt(keySequence.Children[1].Value, keySizeGuess, 8);
             RSAparams.Exponent = keySequence.Children[2].Value;

--- a/AudibleApi/Cryptography.cs
+++ b/AudibleApi/Cryptography.cs
@@ -10,7 +10,7 @@ namespace AudibleApi
 {
     public static class Cryptography
     {
-		public static string Javascript { get; } = File.ReadAllText("Cryptography.js");
+        public static string Javascript { get; } = File.ReadAllText("Cryptography.js");
 
         public static string EncryptMetadata(string metadata)
         {
@@ -86,88 +86,59 @@ namespace AudibleApi
         {
             var dataBytes = Encoding.UTF8.GetBytes(dataString);
 
-			using var sha256 = new SHA256Managed();
-			using var rsaCSP = CreateRsaProviderFromPrivateKey(private_key);
-			var digestion = sha256.ComputeHash(dataBytes);
-			// as string: digestion.Select(x => $"{x:x2}").Aggregate("", (a, b) => a + b);
-			var oid = CryptoConfig.MapNameToOID("SHA256");
-			return rsaCSP.SignHash(digestion, oid);
-		}
+            using var sha256 = new SHA256Managed();
+            using var rsaCSP = CreateRsaProviderFromPrivateKey(private_key);
+            var digestion = sha256.ComputeHash(dataBytes);
+            // as string: digestion.Select(x => $"{x:x2}").Aggregate("", (a, b) => a + b);
+            var oid = CryptoConfig.MapNameToOID("SHA256");
+            return rsaCSP.SignHash(digestion, oid);
+        }
 
-		// https://stackoverflow.com/a/32150537
-		private static RSACryptoServiceProvider CreateRsaProviderFromPrivateKey(string privateKey)
-		{
-			privateKey = privateKey
-				.Replace("-----BEGIN RSA PRIVATE KEY-----", "")
-				.Replace("-----END RSA PRIVATE KEY-----", "")
-				.Replace("\\n", "")
-				.Trim();
-
-			var privateKeyBits = Convert.FromBase64String(privateKey);
-
-			var RSA = new RSACryptoServiceProvider();
-			var RSAparams = new RSAParameters();
-
-			using var binr = new BinaryReader(new MemoryStream(privateKeyBits));
-
-			var twobytes = binr.ReadUInt16();
-			if (twobytes == 0x8130)
-				binr.ReadByte();
-			else if (twobytes == 0x8230)
-				binr.ReadInt16();
-			else
-				throw new Exception("Unexpected value read binr.ReadUInt16()");
-
-			twobytes = binr.ReadUInt16();
-			if (twobytes != 0x0102)
-				throw new Exception("Unexpected version");
-
-			var bt = binr.ReadByte();
-			if (bt != 0x00)
-				throw new Exception("Unexpected value read binr.ReadByte()");
-
-			RSAparams.Modulus = binr.ReadBytes(GetIntegerSize(binr));
-			RSAparams.Exponent = binr.ReadBytes(GetIntegerSize(binr));
-			RSAparams.D = binr.ReadBytes(GetIntegerSize(binr));
-			RSAparams.P = binr.ReadBytes(GetIntegerSize(binr));
-			RSAparams.Q = binr.ReadBytes(GetIntegerSize(binr));
-			RSAparams.DP = binr.ReadBytes(GetIntegerSize(binr));
-			RSAparams.DQ = binr.ReadBytes(GetIntegerSize(binr));
-			RSAparams.InverseQ = binr.ReadBytes(GetIntegerSize(binr));
-
-			RSA.ImportParameters(RSAparams);
-			return RSA;
-		}
-
-        private static int GetIntegerSize(BinaryReader binr)
+        // https://stackoverflow.com/a/32150537
+        private static RSACryptoServiceProvider CreateRsaProviderFromPrivateKey(string privateKey)
         {
-            var bt = binr.ReadByte();
-            if (bt != 0x02)
-                return 0;
+            privateKey = privateKey
+                .Replace("-----BEGIN RSA PRIVATE KEY-----", "")
+                .Replace("-----END RSA PRIVATE KEY-----", "")
+                .Replace("\\n", "")
+                .Trim();
 
-            bt = binr.ReadByte();
+            var asn1EncodedPrivateKey = Convert.FromBase64String(privateKey);
+            var keySequence = Asn1Value.Parse(asn1EncodedPrivateKey);
 
-            int count;
-            if (bt == 0x81)
-                count = binr.ReadByte();
-            else if (bt == 0x82)
-            {
-                var highbyte = binr.ReadByte();
-                var lowbyte = binr.ReadByte();
-                byte[] modint = { lowbyte, highbyte, 0x00, 0x00 };
-                count = BitConverter.ToInt32(modint, 0);
-            }
-            else
-            {
-                count = bt;
-            }
+            var RSA = new RSACryptoServiceProvider();
+            var RSAparams = new RSAParameters();
 
-            while (binr.ReadByte() == 0x00)
+            //Guess the key size based on modulus size. Assume key size is multiple of 128 bits.
+            int keySizeGuess = (int)Math.Round(keySequence.Children[1].Value.Length / 16d, 0) * 128;
+
+            RSAparams.Modulus = ValidateInt(keySequence.Children[1].Value, keySizeGuess, 8);
+            RSAparams.Exponent = keySequence.Children[2].Value;
+            RSAparams.D = ValidateInt(keySequence.Children[3].Value, keySizeGuess, 8);
+            RSAparams.P = ValidateInt(keySequence.Children[4].Value, keySizeGuess, 16);
+            RSAparams.Q = ValidateInt(keySequence.Children[5].Value, keySizeGuess, 16);
+            RSAparams.DP = ValidateInt(keySequence.Children[6].Value, keySizeGuess, 16);
+            RSAparams.DQ = ValidateInt(keySequence.Children[7].Value, keySizeGuess, 16);
+            RSAparams.InverseQ = ValidateInt(keySequence.Children[8].Value, keySizeGuess, 16);
+
+            RSA.ImportParameters(RSAparams);
+            return RSA;
+        }
+
+        /// <summary>
+        /// Trim any leading zeroes to ensure <see cref="RSAParameters"/> are valid.
+        /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/5cf2e6b9-3195-4f85-bc18-05b50e6d4e11?redirectedfrom=MSDN
+        /// </summary>
+        private static byte[] ValidateInt(byte[] integer, int keySize, int quotient)
+        {
+            if (integer.Length != Math.Ceiling(keySize / (double)quotient) &&
+                    integer[0] == 0)
             {
-                count -= 1;
+                var bts = new byte[integer.Length - 1];
+                Buffer.BlockCopy(integer, 1, bts, 0, bts.Length);
+                return bts;
             }
-            binr.BaseStream.Seek(-1, SeekOrigin.Current);
-            return count;
+            return integer;
         }
     }
 }

--- a/AudibleApi/Resources.cs
+++ b/AudibleApi/Resources.cs
@@ -5,7 +5,7 @@ namespace AudibleApi
 {
 	public static class Resources
 	{
-		public const string UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148";
+		public const string UserAgent = "Audible/671 CFNetwork/1240.0.4 Darwin/20.6.0";
 
 		private static string _audibleApiUrl(this Locale locale) => $"https://api.audible.{locale.TopDomain}";
 		public static Uri AudibleApiUri(this Locale locale) => new Uri(locale._audibleApiUrl());

--- a/AudibleApiDTOs/ContentLicenseDtoV10.cs
+++ b/AudibleApiDTOs/ContentLicenseDtoV10.cs
@@ -14,12 +14,18 @@ namespace AudibleApiDTOs
 
     public partial class ContentLicenseDtoV10
     {
+        /// <summary>
+        /// If null, check for <see cref="Message"/>
+        /// </summary>
         [JsonProperty("content_license", Required = Required.Always)]
         public ContentLicense ContentLicense { get; set; }
 
         [JsonProperty("response_groups")]
         public string[] ResponseGroups { get; set; }
 
+        /// <summary>
+        /// If not null, then <see cref="ContentLicense"/> was not returned by the Api.
+        /// </summary>
         [JsonProperty("message")]
         public string Message { get; set; }
     }
@@ -44,6 +50,10 @@ namespace AudibleApiDTOs
         [JsonProperty("license_id")]
         public Guid LicenseId { get; set; }
 
+        /// <summary>
+        /// A base-64 string containing the <see cref="VoucherDtoV10"/> encrypted with the device type, device serial number, amazon accounty ID, and asin.
+        /// See https://patchwork.ffmpeg.org/project/ffmpeg/patch/17559601585196510@sas2-2fa759678732.qloud-c.yandex.net/
+        /// </summary>
         [JsonProperty("license_response")]
         public string LicenseResponse { get; set; }
         

--- a/AudibleApiDTOs/ContentLicenseDtoV10.cs
+++ b/AudibleApiDTOs/ContentLicenseDtoV10.cs
@@ -19,6 +19,9 @@ namespace AudibleApiDTOs
 
         [JsonProperty("response_groups")]
         public string[] ResponseGroups { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
     }
 
     public partial class ContentLicense

--- a/AudibleApiDTOs/LibraryDtoV10.cs
+++ b/AudibleApiDTOs/LibraryDtoV10.cs
@@ -37,7 +37,7 @@ namespace AudibleApiDTOs
 		public int LengthInMinutes => RuntimeLengthMin ?? 0;
 		public string Description => PublisherSummary;
 		public bool IsEpisodes
-			=> Relationships?.Any(r => r.RelationshipToProduct == RelationshipToProduct.Child && r.RelationshipType == RelationshipType.Episode)
+			=> Relationships?.Any(r => (r.RelationshipToProduct == RelationshipToProduct.Child || r.RelationshipToProduct == RelationshipToProduct.Parent) && r.RelationshipType == RelationshipType.Episode)
 			?? false;
 		/// <summary>
 		/// True if this title is an 'Audible Plus' check-out. False if it's owned by the library. More details in comments


### PR DESCRIPTION
As noted in https://github.com/rmcrackan/Libation/issues/82, B09B58W92Z is a podcast episode but it was not being corectly identified as such. It's RelationshipToProduct was "parent" not "child", but RelationshipType was still "episode". I don't know if this is a breaking change, but it doesn't affect my library.

Added more error handling and logging in Api.GetDownloadLicenseAsync().

I also fixed an occasional bug in Cryptography.CreateRsaProviderFromPrivateKey() that would occur if they private key generated by Audible had a mismatch of key component sizes. Technical description follows:

The key components are unsigned integers, but the transport object containing them is a variable-length signed integer. That means that if the true value would decode as a negative number, it would have to be padded with an extra 0-byte to ensure it decodes as a positive value. Depending on the specific key generated this could result, for example, in a Modulus that is 1 byte longer than the private exponent. RSACryptoServiceProvider validates the key components to ensure they meet the criteria listed [here](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/5cf2e6b9-3195-4f85-bc18-05b50e6d4e11?redirectedfrom=MSDN). In the example case, RSACryptoServiceProvider would throw a "Bad Data" error.

Also, RSACryptoServiceProvider infers the key size from the modulus size. Since the modulus could be zero-padded, we need to guess the true key size. I assume the true key size is a multiple of 128 bits, and choose the multiple closest to Modulus.Length.
