### PR TITLE
Minor GetAllLibraryItemsAsync() change

### DIFF
--- a/AudibleApi/Api.Library.cs
+++ b/AudibleApi/Api.Library.cs
@@ -190,8 +190,8 @@ namespace AudibleApi
 	}
 
 	public partial class Api
-    {
-        const string LIBRARY_PATH = "/1.0/library";
+	{
+		const string LIBRARY_PATH = "/1.0/library";
 
 		#region GetLibraryAsync
 		public Task<JObject> GetLibraryAsync()
@@ -282,6 +282,7 @@ namespace AudibleApi
 		#endregion
 
 		#region GetAllLibraryItemsAsync
+		public async Task<List<AudibleApiDTOs.Item>> GetAllLibraryItemsAsync() => await GetAllLibraryItemsAsync(LibraryOptions.ResponseGroupOptions.ALL_OPTIONS);
 		public async Task<List<AudibleApiDTOs.Item>> GetAllLibraryItemsAsync(LibraryOptions.ResponseGroupOptions responseGroups)
 		{
 			var allItems = new List<AudibleApiDTOs.Item>();

--- a/AudibleApi/Api.Library.cs
+++ b/AudibleApi/Api.Library.cs
@@ -282,7 +282,7 @@ namespace AudibleApi
 		#endregion
 
 		#region GetAllLibraryItemsAsync
-		public async Task<List<AudibleApiDTOs.Item>> GetAllLibraryItemsAsync()
+		public async Task<List<AudibleApiDTOs.Item>> GetAllLibraryItemsAsync(LibraryOptions.ResponseGroupOptions responseGroups)
 		{
 			var allItems = new List<AudibleApiDTOs.Item>();
 
@@ -297,7 +297,7 @@ namespace AudibleApi
 					NumberOfResultPerPage = 250,
 					PageNumber = i,
 					PurchasedAfter = new DateTime(2000, 1, 1),
-					ResponseGroups = LibraryOptions.ResponseGroupOptions.ALL_OPTIONS
+					ResponseGroups = responseGroups
 				});
 
 				var pageStr = page.ToString();

--- a/_Demos/AudibleApiClientExample/AudibleApiClient.cs
+++ b/_Demos/AudibleApiClientExample/AudibleApiClient.cs
@@ -271,7 +271,6 @@ namespace AudibleApiClientExample
 		{
 			// if no current lib.json file, run DownloadLibraryToFileAsync() above
 
-
 			var contents = File.ReadAllText(LIBRARY_JSON);
 			var o = JObject.Parse(contents);
 
@@ -296,10 +295,7 @@ namespace AudibleApiClientExample
 			// these are 'plus' and NOT owned by me
 			var AYCL = o.SelectTokens("$.items[?(@.benefit_id == 'AYCL')].title").ToList();
 			var ayce = o.SelectTokens("$.items[?(@.is_ayce == true)].title").ToList();
-			var AYCL_ayce = o.SelectTokens("$.items[?(@.benefit_id == 'AYCL' && @.is_ayce == true)].title").ToList();
-
-
-			var _ = true;
+			var AYCL_ayce = o.SelectTokens("$.items[?(@.benefit_id == 'AYCL' && @.is_ayce == true)].title").ToList();			
 		}
 		#endregion
 	}


### PR DESCRIPTION
```Api.GetAllLibraryItemsAsync``` now requires caller to specify ```LibraryOptions.ResponseGroupOptions```. This was added to speed up the new ```LibraryCommands.FindInactiveBooks``` method in Libation, since that command doesn't care about most of the response groups.