### PR TITLE
Changed OAuth generator to match mkb79 changes in PR 38

### DIFF
--- a/AudibleApi/Authorization/Authorize.cs
+++ b/AudibleApi/Authorization/Authorize.cs
@@ -126,13 +126,11 @@ namespace AudibleApi.Authorization
 			});
 			bodyJson.cookies.website_cookies = new JArray(kvpSelect);
 
-			var serial = getRandomDeviceSerial();
-
 			bodyJson.registration_data = new JObject();
 			bodyJson.registration_data.domain = "Device";
 			bodyJson.registration_data.app_version = appVersion;
-			bodyJson.registration_data.device_serial = serial;
-			bodyJson.registration_data.device_type = "A2CZJZGLK2JJVM";
+			bodyJson.registration_data.device_serial = locale.DeviceSerialNumber;
+			bodyJson.registration_data.device_type = Resources.DeviceType;
 			bodyJson.registration_data.device_name = "%FIRST_NAME%%FIRST_NAME_POSSESSIVE_STRING%%DUPE_STRATEGY_1ST%Audible for iPhone";
 			bodyJson.registration_data.os_version = iosVersion;
 			bodyJson.registration_data.device_model = "iPhone";
@@ -142,26 +140,6 @@ namespace AudibleApi.Authorization
 			bodyJson.requested_extensions = new JArray("device_info", "customer_info");
 
 			return bodyJson;
-		}
-
-		static char[] chars { get; } = new char[] { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
-		static Random random { get; } = new Random();
-		/// <summary>
-		/// Generates a random text (str + int) with a length of 40 chars.
-		/// Use of random serial prevents unregister device by other users with same 'device_serial'
-		/// </summary>
-		/// <returns></returns>
-		private static string getRandomDeviceSerial()
-		{
-			var serialBuilder = new System.Text.StringBuilder();
-			for (var i = 0; i < 40; i++)
-			{
-				var r = random.Next(0, chars.Length);
-				var c = chars[r];
-				serialBuilder.Append(c);
-			}
-			var serial = serialBuilder.ToString();
-			return serial;
 		}
 
 		public async Task<bool> DeregisterAsync(AccessToken accessToken, IEnumerable<KeyValuePair<string, string>> cookies)

--- a/AudibleApi/Locale.cs
+++ b/AudibleApi/Locale.cs
@@ -16,6 +16,7 @@ namespace AudibleApi
 		public string TopDomain { get; }
 		public string MarketPlaceId { get; }
 		public string Language { get; }
+		public string DeviceSerialNumber { get; set; }
 
 		public Locale(string name, string loginDomain, string countryCode, string topDomain, string marketPlaceId, string language)
 		{

--- a/AudibleApi/locales.json
+++ b/AudibleApi/locales.json
@@ -80,11 +80,27 @@
     "language": "es"
   },
   {
-    "name": "pre-amazon",
+    "name": "pre-amazon - germany",
+    "loginDomain": "audible",
+    "countryCode": "de",
+    "topDomain": "de",
+    "marketPlaceId": "AN7V1F1VY261K",
+    "language": "de-DE"
+  },
+  {
+    "name": "pre-amazon - us",
     "loginDomain": "audible",
     "countryCode": "us",
     "topDomain": "com",
     "marketPlaceId": "AF2M0KC94RCEA",
     "language": "en-US"
+  },
+  {
+    "name": "pre-amazon - uk",
+    "loginDomain": "audible",
+    "countryCode": "uk",
+    "topDomain": "co.uk",
+    "marketPlaceId": "A2I9A3Q2GNFNGQ",
+    "language": "en-GB"
   }
 ]


### PR DESCRIPTION
https://github.com/mkb79/Audible/pull/38/files?file-filters%5B%5D=.py

I have no idea if this will help. Libation worked for me with 2fa before and after this change. But this is the PR you mentioned in your email.

As a side note, I really don't like Locale having DeviceSerialNumber, but it was the easiest way to do this with minimal changes.