### PR TITLE
The user app metada "location" property was using the full OAuth url. It only needs the login base URL.

### DIFF
--- a/AudibleApi/Authentication/CredentialsPage.cs
+++ b/AudibleApi/Authentication/CredentialsPage.cs
@@ -125,7 +125,7 @@ namespace AudibleApi.Authentication
 				},
 				{ "referrer", "" },
 				{ "userAgent", Resources.UserAgent },
-				{ "location", locale.OAuthUrl() },
+				{ "location", locale.AmazonLoginUri() },
 				{ "webDriver", null },
 				{  "history",
 					new JObject {


### PR DESCRIPTION
https://github.com/mkb79/Audible/blob/master/src/audible/login.py