### PR TITLE
Add ApiUnauthenticated class

### DIFF
--- a/AudibleApi/Api [partial].cs
+++ b/AudibleApi/Api [partial].cs
@@ -12,28 +12,44 @@ namespace AudibleApi
     // - throw strongly typed exceptions
     public partial class Api
     {
+        public bool IsAuthenticated { get; }
 		public IHttpClientSharer Sharer { get; }
         private IIdentityMaintainer _identityMaintainer { get; }
-        private Locale _locale => _identityMaintainer.Locale;
+        private Locale _locale { get; }
 
         private IHttpClientActions _client
-            => Sharer.GetSharedHttpClient(_identityMaintainer.Locale.AudibleApiUri());
+            => Sharer.GetSharedHttpClient(_locale.AudibleApiUri());
+
+		public Api(Locale locale)
+		{
+			StackBlocker.ApiTestBlocker();
+            _locale = locale;
+            Sharer = new HttpClientSharer();
+            IsAuthenticated = false;
+        }
 
 		public Api(IIdentityMaintainer identityMaintainer)
 		{
 			StackBlocker.ApiTestBlocker();
 
 			_identityMaintainer = identityMaintainer ?? throw new ArgumentNullException(nameof(identityMaintainer));
-			Sharer = new HttpClientSharer();
-		}
+            _locale = _identityMaintainer.Locale;
+            Sharer = new HttpClientSharer();
+            IsAuthenticated = true;
+        }
 
 		public Api(IIdentityMaintainer identityMaintainer, IHttpClientSharer sharer)
 		{
 			_identityMaintainer = identityMaintainer ?? throw new ArgumentNullException(nameof(identityMaintainer));
-			Sharer = sharer ?? throw new ArgumentNullException(nameof(sharer));
-		}
+            _locale = _identityMaintainer.Locale;
+            Sharer = sharer ?? throw new ArgumentNullException(nameof(sharer));
+            IsAuthenticated = true;
+        }
 
-		public async Task<JObject> AdHocNonAuthenticatedGetAsync(string requestUri)
+        public Task<JObject> AdHocNonAuthenticatedGetAsync(string requestUri)
+            => AdHocNonAuthenticatedGetAsync(requestUri, _client);
+
+        public async Task<JObject> AdHocNonAuthenticatedGetAsync(string requestUri, IHttpClientActions client)
         {
             if (requestUri is null)
                 throw new ArgumentNullException(nameof(requestUri));
@@ -42,39 +58,61 @@ namespace AudibleApi
 
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
-            var response = await _client.SendAsync(request);
+            var response = await client.SendAsync(request);
             var responseString = await response.Content.ReadAsStringAsync();
             return JObject.Parse(responseString);
         }
 
 		public Task<HttpResponseMessage> AdHocAuthenticatedGetAsync(string requestUri)
-			=> AdHocAuthenticatedGetAsync(requestUri, _client);
+			=> AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Get, _client);
 
-        public async Task<HttpResponseMessage> AdHocAuthenticatedGetAsync(string requestUri, IHttpClientActions client)
+        public Task<HttpResponseMessage> AdHocAuthenticatedGetAsync(string requestUri, IHttpClientActions client)
+            => AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Get, client);
+
+        public async Task<HttpResponseMessage> AdHocAuthenticatedRequestAsync(string requestUri, HttpMethod method, IHttpClientActions client, JObject postData = null)
         {
             if (requestUri is null)
                 throw new ArgumentNullException(nameof(requestUri));
             if (string.IsNullOrWhiteSpace(requestUri))
                 throw new ArgumentException($"{nameof(requestUri)} may not be blank");
+            if (method is null)
+                throw new ArgumentNullException(nameof(method));
+            if (method.Method == HttpMethod.Post.Method && postData is null)
+                throw new ArgumentNullException(nameof(postData), $"Must provide post data when using {nameof(HttpMethod)}.{nameof(HttpMethod.Post)}");
+            if (!IsAuthenticated)
+                throw new NotAuthenticatedException(new Uri(requestUri), new JObject { "Api is not authenticated" });
 
-            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var request = new HttpRequestMessage(method, requestUri);
 
-            var response = await AdHocAuthenticatedGetAsync(request, client);
-            return response;
-        }
+            if (method.Method == HttpMethod.Post.Method)
+                request.AddContent(postData);
 
-        public async Task<HttpResponseMessage> AdHocAuthenticatedGetAsync(HttpRequestMessage request, IHttpClientActions client)
-        {
-            await signRequestAsync(request);
+            request.SignRequest(
+                    _identityMaintainer.SystemDateTime.UtcNow,
+                    await _identityMaintainer.GetAdpTokenAsync(),
+                    await _identityMaintainer.GetPrivateKeyAsync());
 
             var response = await client.SendAsync(request);
             return response;
         }
 
-        private async Task signRequestAsync(HttpRequestMessage request)
-			=> request.SignRequest(
-				_identityMaintainer.SystemDateTime.UtcNow,
-				await _identityMaintainer.GetAdpTokenAsync(),
-				await _identityMaintainer.GetPrivateKeyAsync());
+        public async Task<HttpResponseMessage> AdHocAuthenticatedGetWithAccessTokenAsync(string requestUri, IHttpClientActions client)
+        {
+            if (requestUri is null)
+                throw new ArgumentNullException(nameof(requestUri));
+            if (string.IsNullOrWhiteSpace(requestUri))
+                throw new ArgumentException($"{nameof(requestUri)} may not be blank");
+            if (!IsAuthenticated)
+                throw new NotAuthenticatedException(new Uri(requestUri), new JObject { "Api is not authenticated" });
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            var accessToken = await _identityMaintainer.GetAccessTokenAsync();
+
+            request.Headers.Add("x-amz-access-token", accessToken.TokenValue);
+
+            var response = await client.SendAsync(request);
+            return response;
+        }
 	}
 }

--- a/AudibleApi/Api [partial].cs
+++ b/AudibleApi/Api [partial].cs
@@ -7,112 +7,76 @@ using Newtonsoft.Json.Linq;
 
 namespace AudibleApi
 {
-    // when possible:
-    // - return strongly-typed data
-    // - throw strongly typed exceptions
-    public partial class Api
-    {
-        public bool IsAuthenticated { get; }
-		public IHttpClientSharer Sharer { get; }
-        private IIdentityMaintainer _identityMaintainer { get; }
-        private Locale _locale { get; }
+	// when possible:
+	// - return strongly-typed data
+	// - throw strongly typed exceptions
+	public partial class Api  : ApiUnauthenticated
+	{
+		public override bool IsAuthenticated => true;
+		private IIdentityMaintainer _identityMaintainer { get; }
 
-        private IHttpClientActions _client
-            => Sharer.GetSharedHttpClient(_locale.AudibleApiUri());
-
-		public Api(Locale locale)
+		public Api(IIdentityMaintainer identityMaintainer) 
+			: base(identityMaintainer?.Locale ?? throw new ArgumentNullException(nameof(identityMaintainer)))
 		{
-			StackBlocker.ApiTestBlocker();
-            _locale = locale;
-            Sharer = new HttpClientSharer();
-            IsAuthenticated = false;
-        }
+			_identityMaintainer = identityMaintainer;
+		}
 
-		public Api(IIdentityMaintainer identityMaintainer)
+		public Api(IIdentityMaintainer identityMaintainer, IHttpClientSharer sharer) 
+			: base(identityMaintainer?.Locale ?? throw new ArgumentNullException(nameof(identityMaintainer)), sharer)
 		{
-			StackBlocker.ApiTestBlocker();
-
-			_identityMaintainer = identityMaintainer ?? throw new ArgumentNullException(nameof(identityMaintainer));
-            _locale = _identityMaintainer.Locale;
-            Sharer = new HttpClientSharer();
-            IsAuthenticated = true;
-        }
-
-		public Api(IIdentityMaintainer identityMaintainer, IHttpClientSharer sharer)
-		{
-			_identityMaintainer = identityMaintainer ?? throw new ArgumentNullException(nameof(identityMaintainer));
-            _locale = _identityMaintainer.Locale;
-            Sharer = sharer ?? throw new ArgumentNullException(nameof(sharer));
-            IsAuthenticated = true;
-        }
-
-        public Task<JObject> AdHocNonAuthenticatedGetAsync(string requestUri)
-            => AdHocNonAuthenticatedGetAsync(requestUri, _client);
-
-        public async Task<JObject> AdHocNonAuthenticatedGetAsync(string requestUri, IHttpClientActions client)
-        {
-            if (requestUri is null)
-                throw new ArgumentNullException(nameof(requestUri));
-            if (string.IsNullOrWhiteSpace(requestUri))
-                throw new ArgumentException($"{nameof(requestUri)} may not be blank");
-
-            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-
-            var response = await client.SendAsync(request);
-            var responseString = await response.Content.ReadAsStringAsync();
-            return JObject.Parse(responseString);
-        }
+			_identityMaintainer = identityMaintainer;
+		}
 
 		public Task<HttpResponseMessage> AdHocAuthenticatedGetAsync(string requestUri)
 			=> AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Get, _client);
 
-        public Task<HttpResponseMessage> AdHocAuthenticatedGetAsync(string requestUri, IHttpClientActions client)
-            => AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Get, client);
+		public Task<HttpResponseMessage> AdHocAuthenticatedGetAsync(string requestUri, IHttpClientActions client)
+			=> AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Get, client);
 
-        public async Task<HttpResponseMessage> AdHocAuthenticatedRequestAsync(string requestUri, HttpMethod method, IHttpClientActions client, JObject postData = null)
-        {
-            if (requestUri is null)
-                throw new ArgumentNullException(nameof(requestUri));
-            if (string.IsNullOrWhiteSpace(requestUri))
-                throw new ArgumentException($"{nameof(requestUri)} may not be blank");
-            if (method is null)
-                throw new ArgumentNullException(nameof(method));
-            if (method.Method == HttpMethod.Post.Method && postData is null)
-                throw new ArgumentNullException(nameof(postData), $"Must provide post data when using {nameof(HttpMethod)}.{nameof(HttpMethod.Post)}");
-            if (!IsAuthenticated)
-                throw new NotAuthenticatedException(new Uri(requestUri), new JObject { "Api is not authenticated" });
+		public async Task<HttpResponseMessage> AdHocAuthenticatedRequestAsync(string requestUri, HttpMethod method, IHttpClientActions client, JObject postData = null)
+		{
+			if (requestUri is null)
+				throw new ArgumentNullException(nameof(requestUri));
+			if (string.IsNullOrWhiteSpace(requestUri))
+				throw new ArgumentException($"{nameof(requestUri)} may not be blank");
+			if (method is null)
+				throw new ArgumentNullException(nameof(method));
+			if (method.Method == HttpMethod.Post.Method && postData is null)
+				throw new ArgumentNullException(nameof(postData), $"Must provide post data when using {nameof(HttpMethod)}.{nameof(HttpMethod.Post)}");
+			if (!IsAuthenticated)
+				throw new NotAuthenticatedException(new Uri(requestUri), new JObject { "Target endpoint requires authentication" });
 
-            var request = new HttpRequestMessage(method, requestUri);
+			var request = new HttpRequestMessage(method, requestUri);
 
-            if (method.Method == HttpMethod.Post.Method)
-                request.AddContent(postData);
+			if (method.Method == HttpMethod.Post.Method)
+				request.AddContent(postData);
 
-            request.SignRequest(
-                    _identityMaintainer.SystemDateTime.UtcNow,
-                    await _identityMaintainer.GetAdpTokenAsync(),
-                    await _identityMaintainer.GetPrivateKeyAsync());
+			request.SignRequest(
+					_identityMaintainer.SystemDateTime.UtcNow,
+					await _identityMaintainer.GetAdpTokenAsync(),
+					await _identityMaintainer.GetPrivateKeyAsync());
 
-            var response = await client.SendAsync(request);
-            return response;
-        }
+			var response = await client.SendAsync(request);
+			return response;
+		}
 
-        public async Task<HttpResponseMessage> AdHocAuthenticatedGetWithAccessTokenAsync(string requestUri, IHttpClientActions client)
-        {
-            if (requestUri is null)
-                throw new ArgumentNullException(nameof(requestUri));
-            if (string.IsNullOrWhiteSpace(requestUri))
-                throw new ArgumentException($"{nameof(requestUri)} may not be blank");
-            if (!IsAuthenticated)
-                throw new NotAuthenticatedException(new Uri(requestUri), new JObject { "Api is not authenticated" });
+		public async Task<HttpResponseMessage> AdHocAuthenticatedGetWithAccessTokenAsync(string requestUri, IHttpClientActions client)
+		{
+			if (requestUri is null)
+				throw new ArgumentNullException(nameof(requestUri));
+			if (string.IsNullOrWhiteSpace(requestUri))
+				throw new ArgumentException($"{nameof(requestUri)} may not be blank");
+			if (!IsAuthenticated)
+				throw new NotAuthenticatedException(new Uri(requestUri), new JObject { "Api is not authenticated" });
 
-            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+			var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
-            var accessToken = await _identityMaintainer.GetAccessTokenAsync();
+			var accessToken = await _identityMaintainer.GetAccessTokenAsync();
 
-            request.Headers.Add("x-amz-access-token", accessToken.TokenValue);
+			request.Headers.Add("x-amz-access-token", accessToken.TokenValue);
 
-            var response = await client.SendAsync(request);
-            return response;
-        }
+			var response = await client.SendAsync(request);
+			return response;
+		}
 	}
 }

--- a/AudibleApi/Api.Content.cs
+++ b/AudibleApi/Api.Content.cs
@@ -1,0 +1,37 @@
+﻿using AudibleApi.Common;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AudibleApi
+{
+    public partial class Api
+    {
+        const string CONTENT_PATH = "/1.0/content";
+		public async Task<ContentMetadata> GetLibraryBookMetadataAsync(string asin)
+		{
+			if (asin is null)
+				throw new ArgumentNullException(nameof(asin));
+			if (string.IsNullOrWhiteSpace(asin))
+				throw new ArgumentException("asin may not be blank", nameof(asin));
+
+			asin = asin.ToUpper().Trim();
+
+			var url = $"{CONTENT_PATH}/{asin}/metadata?response_groups=chapter_info,content_reference";
+			var bookJObj = await AdHocNonAuthenticatedGetAsync(url);
+			var metadataJson = bookJObj.ToString();
+
+			MetadataDtoV10 contentMetadata;
+			try
+			{
+				contentMetadata = MetadataDtoV10.FromJson(metadataJson);
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Logger.Error(ex, $"Error retrieving content metadata for asin: {asin}");
+				throw;
+			}
+			return contentMetadata?.ContentMetadata;
+		}
+	}
+}

--- a/AudibleApi/Api.Customer.cs
+++ b/AudibleApi/Api.Customer.cs
@@ -10,36 +10,6 @@ using Newtonsoft.Json.Linq;
 
 namespace AudibleApi
 {
-	public static class CustomerQueryStringBuilderExtensions
-	{
-		public static string ToQueryString(this CustomerOptions.ResponseGroupOptions responseGroupOptions)
-		{
-			if (responseGroupOptions == CustomerOptions.ResponseGroupOptions.None)
-				return "";
-
-			var descriptions = responseGroupOptions
-				.ToValues()
-				.Select(e => e.GetDescription())
-				.ToList();
-			if (!descriptions.Any() || descriptions.Any(d => d is null))
-				throw new Exception("Unexpected value in response group");
-			var str = "response_groups=" + descriptions.Aggregate((a, b) => $"{a},{b}");
-			return str;
-		}
-
-		public static string ToQueryString(this CustomerOptions customerOptions)
-		{
-			var parameters = new List<string>();
-
-			if (customerOptions.ResponseGroups != CustomerOptions.ResponseGroupOptions.None)
-				parameters.Add(customerOptions.ResponseGroups.ToQueryString());
-
-			if (!parameters.Any())
-				return "";
-
-			return parameters.Aggregate((a, b) => $"{a}&{b}");
-		}
-	}
 	public class CustomerOptions
 	{
 		public static CustomerOptions All => new CustomerOptions { ResponseGroups = ResponseGroupOptions.ALL_OPTIONS };
@@ -58,10 +28,21 @@ namespace AudibleApi
 			CustomerSegment = 1 << 3,
 			[Description("subscription_details_channels")]
 			SubscriptionDetailsChannels = 1 << 4,
-			// https://stackoverflow.com/questions/7467722
-			ALL_OPTIONS = ~(1 << 5)
+			ALL_OPTIONS = (1 << 5) - 1
 		}
 		public ResponseGroupOptions ResponseGroups { get; set; }
+		public string ToQueryString()
+		{
+			var parameters = new List<string>();
+
+			if (ResponseGroups != ResponseGroupOptions.None)
+				parameters.Add(ResponseGroups.ToResponseGroupsQueryString());
+
+			if (!parameters.Any())
+				return "";
+
+			return parameters.Aggregate((a, b) => $"{a}&{b}");
+		}
 	}
 
 	public partial class Api

--- a/AudibleApi/Api.Customer.cs
+++ b/AudibleApi/Api.Customer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Dinah.Core;
 using Dinah.Core.Net.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/AudibleApi/Api.User.cs
+++ b/AudibleApi/Api.User.cs
@@ -26,9 +26,8 @@ namespace AudibleApi
 			// note: this call uses the amazon api uri, NOT audible
 			var client = Sharer.GetSharedHttpClient(_locale.AmazonApiUri());
 
-            var accessToken = await _identityMaintainer.GetAccessTokenAsync();
-            var request = new HttpRequestMessage(HttpMethod.Get, $"/user/profile?access_token={accessToken.TokenValue}");
-            var response = await client.SendAsync(request);
+            var response = await AdHocAuthenticatedGetWithAccessTokenAsync($"/user/profile", client);
+
             var json = await response.Content.ReadAsStringAsync();
 
             // return full json string. consumer to parse it

--- a/AudibleApi/Api.User.cs
+++ b/AudibleApi/Api.User.cs
@@ -1,37 +1,31 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
-using AudibleApi.Authorization;
-using Dinah.Core;
 using Newtonsoft.Json.Linq;
 
 namespace AudibleApi
 {
-    public partial class Api
-    {
-        /// <summary>Get email from: /user/profile</summary>
-        public async Task<string> GetEmailAsync()
-        {
-            var u = await UserProfileAsync();
-            var email = u["email"].Value<string>();
-            return email;
-        }
+	public partial class Api
+	{
+		/// <summary>Get email from: /user/profile</summary>
+		public async Task<string> GetEmailAsync()
+		{
+			var u = await UserProfileAsync();
+			var email = u["email"].Value<string>();
+			return email;
+		}
 
-        public async Task<JObject> UserProfileAsync()
-        {
+		public async Task<JObject> UserProfileAsync()
+		{
 			// note: this call uses the amazon api uri, NOT audible
 			var client = Sharer.GetSharedHttpClient(_locale.AmazonApiUri());
 
-            var response = await AdHocAuthenticatedGetWithAccessTokenAsync($"/user/profile", client);
+			var response = await AdHocAuthenticatedGetWithAccessTokenAsync($"/user/profile", client);
 
-            var json = await response.Content.ReadAsStringAsync();
+			var json = await response.Content.ReadAsStringAsync();
 
-            // return full json string. consumer to parse it
-            return JObject.Parse(json);
-        }
-    }
+			// return full json string. consumer to parse it
+			return JObject.Parse(json);
+		}
+	}
 }

--- a/AudibleApi/Api.WishList.cs
+++ b/AudibleApi/Api.WishList.cs
@@ -57,19 +57,13 @@ namespace AudibleApi
 
             var body = JObject.Parse($@"{{""asin"":""{asin}""}}");
 
-            var request = new HttpRequestMessage(HttpMethod.Post, WISHLIST_PATH);
-            // POST body: see AddContent overloads
-            request.AddContent(body);
-
-            await signRequestAsync(request);
-
-            var response = await _client.SendAsync(request);
+            var response = await AdHocAuthenticatedRequestAsync(WISHLIST_PATH, HttpMethod.Post, _client, body);
             var responseString = await response.Content.ReadAsStringAsync();
 
             // same return values whether it already existed in wish list or newly added
             if (response.StatusCode != HttpStatusCode.Created)
                 throw new ApiErrorException(
-                    request.RequestUri,
+                    new Uri(WISHLIST_PATH),
                     JObject.Parse(responseString),
                     $"Add to Wish List failed. Invalid status code. Code: {response.StatusCode}"
                     );
@@ -77,7 +71,7 @@ namespace AudibleApi
             var location = response.Headers.Location.ToString();
             if (location != $"{WISHLIST_PATH}/{asin}")
                 throw new ApiErrorException(
-                    request.RequestUri,
+                    new Uri(WISHLIST_PATH),
                     JObject.Parse(responseString),
                     $"Add to Wish List failed. Bad location. Location: {location}"
                     );
@@ -91,17 +85,14 @@ namespace AudibleApi
                 throw new ArgumentException();
 
             var requestUri = $"{WISHLIST_PATH}/{asin}";
-            var request = new HttpRequestMessage(HttpMethod.Delete, requestUri);
 
-            await signRequestAsync(request);
-
-            var response = await _client.SendAsync(request);
+            var response = await AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Delete, _client);
             var responseString = await response.Content.ReadAsStringAsync();
 
             // same return values whether it already existed in wish list or newly added
             if (response.StatusCode != HttpStatusCode.NoContent)
                 throw new ApiErrorException(
-                    request.RequestUri,
+                    new Uri(requestUri),
                     JObject.Parse(responseString),
                     $"Delete from Wish List failed. Invalid status code. Code: {response.StatusCode}. Asin: {asin}"
                     );

--- a/AudibleApi/Api.WishList.cs
+++ b/AudibleApi/Api.WishList.cs
@@ -8,94 +8,94 @@ using Newtonsoft.Json.Linq;
 
 namespace AudibleApi
 {
-    public partial class Api
-    {
-        const string WISHLIST_PATH = "/1.0/wishlist";
+	public partial class Api
+	{
+		const string WISHLIST_PATH = "/1.0/wishlist";
 
-        public async Task<bool> IsInWishListAsync(string asin)
-        {
-            if (asin is null)
-                throw new ArgumentNullException(nameof(asin));
-            if (string.IsNullOrWhiteSpace(asin))
-                throw new ArgumentException();
+		public async Task<bool> IsInWishListAsync(string asin)
+		{
+			if (asin is null)
+				throw new ArgumentNullException(nameof(asin));
+			if (string.IsNullOrWhiteSpace(asin))
+				throw new ArgumentException();
 
-            // test with page results = 10. for production => 50
-            var num_results = 50;
+			// test with page results = 10. for production => 50
+			var num_results = 50;
 
-            // pages are 0 indexed
-            var page = 0;
-            var accum = 0;
-            int total_results;
+			// pages are 0 indexed
+			var page = 0;
+			var accum = 0;
+			int total_results;
 
-            // iterate through all pages
-            do
-            {
-                var url = $"{WISHLIST_PATH}?num_results={num_results}&page={page}&sort_by=-DateAdded";
-                var response = await AdHocAuthenticatedGetAsync(url);
+			// iterate through all pages
+			do
+			{
+				var url = $"{WISHLIST_PATH}?num_results={num_results}&page={page}&sort_by=-DateAdded";
+				var response = await AdHocAuthenticatedGetAsync(url);
 				var obj = await response.Content.ReadAsJObjectAsync();
 
 				var products = obj["products"] as JArray;
 
-                page++;
-                accum += products.Count;
-                total_results = (int)obj["total_results"];
+				page++;
+				accum += products.Count;
+				total_results = (int)obj["total_results"];
 
-                if (products.Any(p => p.Value<string>("asin") == asin))
-                    return true;
-            }
-            while (accum < total_results);
+				if (products.Any(p => p.Value<string>("asin") == asin))
+					return true;
+			}
+			while (accum < total_results);
 
-            return false;
-        }
+			return false;
+		}
 
-        public async Task AddToWishListAsync(string asin)
-        {
-            if (asin is null)
-                throw new ArgumentNullException(nameof(asin));
-            if (string.IsNullOrWhiteSpace(asin))
-                throw new ArgumentException();
+		public async Task AddToWishListAsync(string asin)
+		{
+			if (asin is null)
+				throw new ArgumentNullException(nameof(asin));
+			if (string.IsNullOrWhiteSpace(asin))
+				throw new ArgumentException();
 
-            var body = JObject.Parse($@"{{""asin"":""{asin}""}}");
+			var body = JObject.Parse($@"{{""asin"":""{asin}""}}");
 
-            var response = await AdHocAuthenticatedRequestAsync(WISHLIST_PATH, HttpMethod.Post, _client, body);
-            var responseString = await response.Content.ReadAsStringAsync();
+			var response = await AdHocAuthenticatedRequestAsync(WISHLIST_PATH, HttpMethod.Post, _client, body);
+			var responseString = await response.Content.ReadAsStringAsync();
 
-            // same return values whether it already existed in wish list or newly added
-            if (response.StatusCode != HttpStatusCode.Created)
-                throw new ApiErrorException(
-                    new Uri(WISHLIST_PATH),
-                    JObject.Parse(responseString),
-                    $"Add to Wish List failed. Invalid status code. Code: {response.StatusCode}"
-                    );
+			// same return values whether it already existed in wish list or newly added
+			if (response.StatusCode != HttpStatusCode.Created)
+				throw new ApiErrorException(
+					new Uri(WISHLIST_PATH),
+					JObject.Parse(responseString),
+					$"Add to Wish List failed. Invalid status code. Code: {response.StatusCode}"
+					);
 
-            var location = response.Headers.Location.ToString();
-            if (location != $"{WISHLIST_PATH}/{asin}")
-                throw new ApiErrorException(
-                    new Uri(WISHLIST_PATH),
-                    JObject.Parse(responseString),
-                    $"Add to Wish List failed. Bad location. Location: {location}"
-                    );
-        }
+			var location = response.Headers.Location.ToString();
+			if (location != $"{WISHLIST_PATH}/{asin}")
+				throw new ApiErrorException(
+					new Uri(WISHLIST_PATH),
+					JObject.Parse(responseString),
+					$"Add to Wish List failed. Bad location. Location: {location}"
+					);
+		}
 
-        public async Task DeleteFromWishListAsync(string asin)
-        {
-            if (asin is null)
-                throw new ArgumentNullException(nameof(asin));
-            if (string.IsNullOrWhiteSpace(asin))
-                throw new ArgumentException();
+		public async Task DeleteFromWishListAsync(string asin)
+		{
+			if (asin is null)
+				throw new ArgumentNullException(nameof(asin));
+			if (string.IsNullOrWhiteSpace(asin))
+				throw new ArgumentException();
 
-            var requestUri = $"{WISHLIST_PATH}/{asin}";
+			var requestUri = $"{WISHLIST_PATH}/{asin}";
 
-            var response = await AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Delete, _client);
-            var responseString = await response.Content.ReadAsStringAsync();
+			var response = await AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Delete, _client);
+			var responseString = await response.Content.ReadAsStringAsync();
 
-            // same return values whether it already existed in wish list or newly added
-            if (response.StatusCode != HttpStatusCode.NoContent)
-                throw new ApiErrorException(
-                    new Uri(requestUri),
-                    JObject.Parse(responseString),
-                    $"Delete from Wish List failed. Invalid status code. Code: {response.StatusCode}. Asin: {asin}"
-                    );
-        }
-    }
+			// same return values whether it already existed in wish list or newly added
+			if (response.StatusCode != HttpStatusCode.NoContent)
+				throw new ApiErrorException(
+					new Uri(requestUri),
+					JObject.Parse(responseString),
+					$"Delete from Wish List failed. Invalid status code. Code: {response.StatusCode}. Asin: {asin}"
+					);
+		}
+	}
 }

--- a/AudibleApi/ApiUnauthenticated [partial].cs
+++ b/AudibleApi/ApiUnauthenticated [partial].cs
@@ -1,0 +1,46 @@
+﻿using Dinah.Core.Net.Http;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace AudibleApi
+{
+	public partial class ApiUnauthenticated
+	{
+		public virtual bool IsAuthenticated => false;
+		public IHttpClientSharer Sharer { get; }
+		protected Locale _locale { get; }
+		protected IHttpClientActions _client
+			=> Sharer.GetSharedHttpClient(_locale.AudibleApiUri());
+
+		public ApiUnauthenticated(Locale locale, IHttpClientSharer sharer)
+		{
+			_locale = locale;
+			Sharer = sharer ?? throw new ArgumentNullException(nameof(sharer));
+		}
+
+		public ApiUnauthenticated(Locale locale)
+		{
+			StackBlocker.ApiTestBlocker();
+			_locale = locale;
+			Sharer = new HttpClientSharer();
+		}
+
+		public Task<HttpResponseMessage> AdHocNonAuthenticatedGetAsync(string requestUri)
+			=> AdHocNonAuthenticatedGetAsync(requestUri, _client);
+
+		public async Task<HttpResponseMessage> AdHocNonAuthenticatedGetAsync(string requestUri, IHttpClientActions client)
+		{
+			if (requestUri is null)
+				throw new ArgumentNullException(nameof(requestUri));
+			if (string.IsNullOrWhiteSpace(requestUri))
+				throw new ArgumentException($"{nameof(requestUri)} may not be blank");
+
+			var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+			var response = await client.SendAsync(request);
+			return response;
+		}
+	}
+}

--- a/AudibleApi/ApiUnauthenticated.Catalog.cs
+++ b/AudibleApi/ApiUnauthenticated.Catalog.cs
@@ -93,9 +93,9 @@ namespace AudibleApi
 		}
 	}
 
-	public partial class Api
+	public partial class ApiUnauthenticated
 	{
-		const string CATALOG_PATH = "/1.0/catalog";
+		protected const string CATALOG_PATH = "/1.0/catalog";
 
 		public async Task<Item> GetCatalogProductAsync(string asin, CatalogOptions.ResponseGroupOptions responseGroups)
 			=> (await GetCatalogProductsAsync(new CatalogOptions { ResponseGroups = responseGroups, Asins = new() { asin } })).Single();
@@ -114,8 +114,8 @@ namespace AudibleApi
 			var url = $"{CATALOG_PATH}/products/";
 			if (!string.IsNullOrWhiteSpace(options))
 				url += "?" + options;
-			var obj = await AdHocNonAuthenticatedGetAsync(url);
-			var objStr = obj.ToString();
+			var response = await AdHocNonAuthenticatedGetAsync(url);
+			var objStr = await response.Content.ReadAsStringAsync();
 
 			ProductsDtoV10 dto;
 			try

--- a/AudibleApi/ApiUnauthenticated.Content.cs
+++ b/AudibleApi/ApiUnauthenticated.Content.cs
@@ -5,10 +5,10 @@ using System.Threading.Tasks;
 
 namespace AudibleApi
 {
-    public partial class Api
-    {
-        const string CONTENT_PATH = "/1.0/content";
-		public async Task<ContentMetadata> GetLibraryBookMetadataAsync(string asin)
+    public partial class ApiUnauthenticated
+	{
+        protected const string CONTENT_PATH = "/1.0/content";
+		public async Task<ContentMetadata> GetContentMetadataAsync(string asin)
 		{
 			if (asin is null)
 				throw new ArgumentNullException(nameof(asin));
@@ -18,8 +18,9 @@ namespace AudibleApi
 			asin = asin.ToUpper().Trim();
 
 			var url = $"{CONTENT_PATH}/{asin}/metadata?response_groups=chapter_info,content_reference";
-			var bookJObj = await AdHocNonAuthenticatedGetAsync(url);
-			var metadataJson = bookJObj.ToString();
+
+			var response = await AdHocNonAuthenticatedGetAsync(url);
+			var metadataJson = await response.Content.ReadAsStringAsync();
 
 			MetadataDtoV10 contentMetadata;
 			try

--- a/AudibleApi/AudibleApi.csproj
+++ b/AudibleApi/AudibleApi.csproj
@@ -9,10 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi.Common" Version="3.0.2.1" />
     <PackageReference Include="Jint" Version="2.11.58" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\AudibleApi.Common\AudibleApi.Common.csproj" />
+	</ItemGroup>
 
   <ItemGroup>
     <Compile Update="Api.*.cs">

--- a/AudibleApi/AudibleApi.csproj
+++ b/AudibleApi/AudibleApi.csproj
@@ -19,6 +19,12 @@
       <DependentUpon>Api [partial].cs</DependentUpon>
     </Compile>
   </ItemGroup>
+	
+  <ItemGroup>
+    <Compile Update="ApiUnauthenticated.*.cs">
+      <DependentUpon>ApiUnauthenticated [partial].cs</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Update="EzApiCreator.*.cs">

--- a/AudibleApi/Cryptography.cs
+++ b/AudibleApi/Cryptography.cs
@@ -84,7 +84,7 @@ namespace AudibleApi
         {
             var dataBytes = Encoding.UTF8.GetBytes(dataString);
 
-            using var sha256 = new SHA256Managed();
+            using var sha256 = SHA256.Create();
             using var rsaCSP = CreateRsaProviderFromPrivateKey(private_key);
             var digestion = sha256.ComputeHash(dataBytes);
             // as string: digestion.Select(x => $"{x:x2}").Aggregate("", (a, b) => a + b);
@@ -107,7 +107,7 @@ namespace AudibleApi
             var RSA = new RSACryptoServiceProvider();
             var RSAparams = new RSAParameters();
 
-            //Guess the key size based on modulus size. Assume key size is multiple of 128 bits.
+            //Guess the key size based on modulus size. Assume key size is multiple of 32 bits.
             int keySizeGuess = (int)Math.Round(keySequence.Children[1].Value.Length / 4d, 0) * 32;
 
             RSAparams.Modulus = ValidateInt(keySequence.Children[1].Value, keySizeGuess, 8);

--- a/AudibleApi/QueryOptionsStringBuilderExtensions.cs
+++ b/AudibleApi/QueryOptionsStringBuilderExtensions.cs
@@ -43,20 +43,13 @@ namespace AudibleApi
 			return description;
 		}
 
-		private static IEnumerable<string> getFlaggedDescriptions(this Enum input, bool checkZero = false, bool checkFlags = true)
+		private static IEnumerable<string> getFlaggedDescriptions(this Enum input)
 		{
 			Type enumType = input.GetType();
 			if (!enumType.IsEnum)
 				yield break;
 
 			ulong setBits = Convert.ToUInt64(input);
-			// if no flags are set, return empty
-			if (!checkZero && (0 == setBits))
-				yield break;
-
-			// if it's not a flag enum, return empty
-			if (checkFlags && !enumType.IsDefined(typeof(FlagsAttribute), false))
-				yield break;
 
 			// check each enum value mask if it is in input bits
 			foreach (Enum value in Enum.GetValues(enumType))

--- a/AudibleApi/QueryOptionsStringBuilderExtensions.cs
+++ b/AudibleApi/QueryOptionsStringBuilderExtensions.cs
@@ -1,0 +1,86 @@
+﻿using Dinah.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AudibleApi
+{
+	internal static class QueryOptionsStringBuilderExtensions
+	{
+		internal static string ToResponseGroupsQueryString(this Enum responseGroupOptions)
+			=> "response_groups=" + responseGroupOptions.ToFlagDescriptions();
+		internal static string ToImageSizesQueryString(this Enum responseGroupOptions)
+			=> "image_sizes=" + responseGroupOptions.ToFlagDescriptions();
+		internal static string ToSortByQueryString(this Enum responseGroupOptions)
+			=> "sort_by=" + responseGroupOptions.ToDescription();
+
+		private static string ToFlagDescriptions(this Enum flagEnumValue)
+		{
+			if (!flagEnumValue.GetType().IsDefined(typeof(FlagsAttribute), false))
+				throw new ArgumentException($"This method only supports enum types with Flags attribute.");
+
+			if (Convert.ToUInt64(flagEnumValue) == 0)
+				return "";
+
+			var descriptions = flagEnumValue.getFlaggedDescriptions().ToList();
+
+			if (!descriptions.Any() || descriptions.Any(d => d is null))
+				throw new Exception("Unexpected value in response group");
+			return descriptions.Aggregate((a, b) => $"{a},{b}");
+		}
+
+		private static string ToDescription(this Enum enumValue)
+		{
+			if (enumValue.GetType().IsDefined(typeof(FlagsAttribute), false))
+				throw new ArgumentException($"This method does no support enum types with Flags attribute.");
+
+			if (Convert.ToUInt64(enumValue) == 0)
+				return "";
+
+			var description = enumValue.GetDescription();
+			if (description is null)
+				throw new Exception("Unexpected value for sort by");
+			return description;
+		}
+
+		private static IEnumerable<string> getFlaggedDescriptions(this Enum input, bool checkZero = false, bool checkFlags = true)
+		{
+			Type enumType = input.GetType();
+			if (!enumType.IsEnum)
+				yield break;
+
+			ulong setBits = Convert.ToUInt64(input);
+			// if no flags are set, return empty
+			if (!checkZero && (0 == setBits))
+				yield break;
+
+			// if it's not a flag enum, return empty
+			if (checkFlags && !enumType.IsDefined(typeof(FlagsAttribute), false))
+				yield break;
+
+			// check each enum value mask if it is in input bits
+			foreach (Enum value in Enum.GetValues(enumType))
+			{
+				ulong valMask = Convert.ToUInt64(value);
+
+				if ((setBits & valMask) == valMask && isPowerOfTwo(valMask))
+					yield return value.GetDescription();
+			}
+		}
+
+		static bool isPowerOfTwo(ulong n)
+		{
+			if (n == 0)
+				return false;
+
+			while (n != 1)
+			{
+				if (n % 2 != 0)
+					return false;
+
+				n /= 2;
+			}
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
As @mkb79 [pointed out](https://github.com/rmcrackan/Libation/issues/220#issuecomment-1082605179), the content `content/[asin]/metadata` endpoint doesn't require authentication.  I've discovered that the `/1.0/catalog/products` endpoint also doe not require authentication.  To make the best use of these unauthenticated calls, I've made a new class, `ApiUnauthenticated`, that only required a Locale. `Api` now inherits `ApiUnauthenticated`

Additionally, I moved a lot of the enum -> query string code to it's own extension class `QueryOptionsStringBuilderExtensions` that can be resued with all enum types.