### PR TITLE
Fix bugs discussed in https://github.com/rmcrackan/Libation/issues/286

### DIFF
--- a/AudibleApi/Api [partial].cs
+++ b/AudibleApi/Api [partial].cs
@@ -54,8 +54,7 @@ namespace AudibleApi
 					await _identityMaintainer.GetAdpTokenAsync(),
 					await _identityMaintainer.GetPrivateKeyAsync());
 
-			var response = await client.SendAsync(request);
-			return response;
+			return await SendClientRequest(client, request);
 		}
 
 		public async Task<HttpResponseMessage> AdHocAuthenticatedGetWithAccessTokenAsync(string requestUri, IHttpClientActions client)
@@ -71,8 +70,7 @@ namespace AudibleApi
 
 			request.Headers.Add("x-amz-access-token", accessToken.TokenValue);
 
-			var response = await client.SendAsync(request);
-			return response;
+			return await SendClientRequest(client, request);
 		}
 	}
 }

--- a/AudibleApi/Api.Download.cs
+++ b/AudibleApi/Api.Download.cs
@@ -140,52 +140,6 @@ namespace AudibleApi
 
         #endregion
 
-        public async Task<string> GetPdfDownloadLinkAsync(string asin)
-        {
-            //// SEPT 2020:
-
-            //// no longer works. This url now returns 403
-            // var downloadUrl = libraryBook?.Book?.Supplements?.FirstOrDefault()?.Url;
-
-            //// this works for now:
-            // MUST use relative url here
-            var client = Sharer.GetSharedHttpClient(Locale.AudibleLoginUri());
-            var response = await AdHocAuthenticatedRequestAsync($"/companion-file/{asin}", HttpMethod.Head, client);
-
-            validatePdfDownloadUrl(asin, response);
-
-            var downloadUrl = response.Headers.Location.AbsoluteUri;
-            return downloadUrl;
-        }
-
-        // keep the brackets, the key, the colon, and the first and last 2 char.s.
-        // Assumes value is 4+ characters long
-        private System.Text.RegularExpressions.Regex adpTokenRegex = new("{([a-z]+:..).*?(..)}", System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled);
-        // same as above but for "device-token"
-        private System.Text.RegularExpressions.Regex deviceTokenRegex = new("(device-token=..).*?(..;)", System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Compiled);
-        private string regexReplacement = "$1...$2";
-        private void validatePdfDownloadUrl(string asin, HttpResponseMessage response)
-        {
-            var body = $"\r\nASIN:{asin}\r\nLocale:{Locale}";
-
-            if (response is null)
-                throw new HttpRequestException("Response is null." + body);
-
-            body += $"\r\nStatus Code:{(int)response.StatusCode} - {response.StatusCode}";
-
-            // mask for log output
-            // original:
-            //   device-token=aZ/aZ/aZ; Domain=.audible.com; Expires=Wed, 22-Jun-2022 17:14:43 GMT; Path=/; Secure; HttpOnly, adpToken="{enc:a1Z+/=}{key:a1Z+/==}{iv:a1Z+/==}{name:AAZ1}{serial:Mg==}"; Domain=.audible.com;
-            // result:
-            // device-token=aZ...aZ; Domain=.audible.com; Expires=Wed, 22-Jun-2022 17:14:43 GMT; Path=/; Secure; HttpOnly, adpToken="{enc:a1.../=}{key:a1...==}{iv:a1...==}{name:AA...Z1}{serial:Mg...==}"; Domain=.audible.com;
-            body = adpTokenRegex.Replace(body, regexReplacement);
-            body = deviceTokenRegex.Replace(body, regexReplacement);
-
-            if (response.Headers is null)
-                throw new HttpRequestException("Response Headers are null." + body);
-
-            if (response.Headers.Location is null)
-                throw new HttpRequestException("Response Location is null." + body + $"\r\n{response.Headers}");
-        }
+        public async Task<string> GetPdfDownloadLinkAsync(string asin) => (await GetDownloadLicenseAsync(asin)).PdfUrl;
     }
 }

--- a/AudibleApi/ApiUnauthenticated [partial].cs
+++ b/AudibleApi/ApiUnauthenticated [partial].cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AudibleApi
@@ -39,8 +40,24 @@ namespace AudibleApi
 
 			var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
-			var response = await client.SendAsync(request);
-			return response;
+			return await SendClientRequest(client, request);
+		}
+
+		protected async Task<HttpResponseMessage> SendClientRequest(IHttpClientActions client, HttpRequestMessage request)
+		{
+			var cts = new CancellationTokenSource();
+			try
+			{
+				return await client.SendAsync(request, cts.Token);
+			}
+			catch (TaskCanceledException ex)
+			{
+				if (ex.CancellationToken != cts.Token)
+				{
+					throw new ApiErrorException(request.RequestUri, new Newtonsoft.Json.Linq.JObject { { "http_error", "Timeout" } });
+				}
+				else throw;
+			}
 		}
 	}
 }

--- a/AudibleApi/ApiUnauthenticated [partial].cs
+++ b/AudibleApi/ApiUnauthenticated [partial].cs
@@ -45,18 +45,18 @@ namespace AudibleApi
 
 		protected async Task<HttpResponseMessage> SendClientRequest(IHttpClientActions client, HttpRequestMessage request)
 		{
-			var cts = new CancellationTokenSource();
+			//https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.sendasync?view=net-6.0
 			try
 			{
-				return await client.SendAsync(request, cts.Token);
+				return await client.SendAsync(request);
 			}
-			catch (TaskCanceledException ex)
+			catch (TaskCanceledException)
 			{
-				if (ex.CancellationToken != cts.Token)
-				{
-					throw new ApiErrorException(request.RequestUri, new Newtonsoft.Json.Linq.JObject { { "http_error", "Timeout" } });
-				}
-				else throw;
+				throw new ApiErrorException(request.RequestUri, new Newtonsoft.Json.Linq.JObject { { "http_error", "The request failed due to timeout." } });
+			}
+			catch (HttpRequestException)
+			{
+				throw new ApiErrorException(request.RequestUri, new Newtonsoft.Json.Linq.JObject { { "http_error", "The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout." } });
 			}
 		}
 	}


### PR DESCRIPTION
- Add additional checks to ValidateInt for parsing RSA params
- Detect http errors and throw custom exception. Should make for cleaner and more useful log files.
- Use the GetDownloadLicenseAsync to get the pdf URL

[You said to preserve debugging stuff in validatePdfDownloadUrl](https://github.com/rmcrackan/Libation/issues/286#issuecomment-1164644586), but there's really no way I can see to do that.  The `ContentLicense` returned by `GetDownloadLicenseAsync` contains the final pdf download link, so there is nothing to validate.