### PR TITLE
Add ContentLicenseDeniedException

### DIFF
--- a/AudibleApi.Common/Enums.cs
+++ b/AudibleApi.Common/Enums.cs
@@ -304,4 +304,34 @@ namespace AudibleApi.Common
 		public const string Series = "series";
 	}
 	#endregion
+
+	#region License Rejection
+
+	/// <summary>
+	/// RejectionReason
+	///		[JsonProperty("rejectionReason")]
+	///		public string RejectionReason { get; set; }
+	/// </summary>
+
+	public static class RejectionReason
+	{
+		public const string ContentEligibility = "ContentEligibility";
+		public const string RequesterEligibility = "RequesterEligibility";
+		public const string GenericError = "GenericError";
+	}
+
+	/// <summary>
+	/// RejectionReason
+	///		[JsonProperty("rejectionReason")]
+	///		public string ValidationType { get; set; }
+	/// </summary>
+	public static class ValidationType
+	{
+		public const string Client = "Client";
+		public const string Ownership = "Ownership";
+		public const string Membership = "Membership";
+		public const string AYCL = "AYCL";
+	}
+
+	#endregion
 }

--- a/AudibleApi/ApiExceptions/AudibleApiException.cs
+++ b/AudibleApi/ApiExceptions/AudibleApiException.cs
@@ -7,7 +7,7 @@ namespace AudibleApi
     {
         public string RequestUri { get; }
         // strore as string, not dynamic JObject. Serilog sometimes prints dynamic JObject as "[[[]]]"
-        public string JsonMessage { get; }
+        public string JsonMessage { get; protected init; }
 
         public AudibleApiException(Uri requestUri, JObject jsonMessage) : this(requestUri, jsonMessage, null, null) { }
 
@@ -18,7 +18,7 @@ namespace AudibleApi
         public AudibleApiException(string requestUri, JObject jsonMessage, string message, Exception innerException) : base(message, innerException)
         {
             RequestUri = requestUri;
-            JsonMessage = jsonMessage.ToString(Newtonsoft.Json.Formatting.None);
+            JsonMessage = jsonMessage?.ToString(Newtonsoft.Json.Formatting.None);
         }
     }
 }

--- a/AudibleApi/ApiExceptions/ContentLicenseDeniedException.cs
+++ b/AudibleApi/ApiExceptions/ContentLicenseDeniedException.cs
@@ -1,0 +1,43 @@
+﻿using AudibleApi.Common;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AudibleApi
+{
+	public class ContentLicenseDeniedException : AudibleApiException
+	{
+		private static readonly Regex CustomerIdPattern = new("\\[A\\w{10,20}\\]", RegexOptions.Compiled);
+		public LicenseDenialReason Client { get; }
+		public LicenseDenialReason Ownership { get; }
+		public LicenseDenialReason Membership { get; }
+		public LicenseDenialReason AYCL { get; }
+
+		public ContentLicenseDeniedException(Uri requestUri, ContentLicense license) : this(requestUri, license, null) { }
+
+		public ContentLicenseDeniedException(Uri requestUri, ContentLicense license, Exception innerException) : base(requestUri,  null, $"Content License denied for asin: [{license.Asin}]", innerException)
+		{
+			if (license?.LicenseDenialReasons is null)
+			{
+				JsonMessage = new JObject { { "license_denial_reasons", "NO REASONS GIVEN" } }.ToString(Newtonsoft.Json.Formatting.None);
+				return;
+			}
+
+			var reasonList = license.LicenseDenialReasons.Select(r =>
+			{
+				if (r.Message is not null)
+					r.Message = CustomerIdPattern.Replace(r.Message, "[##############]"); //Replace personally identifying customer ID.
+				return JObject.FromObject(r);
+			});
+
+			JsonMessage = new JObject { { "license_denial_reasons", JArray.FromObject(reasonList) } }.ToString(Newtonsoft.Json.Formatting.None);
+
+			// This should properly be Single() not FirstOrDefault(), but FirstOrDefault is defensive for malformed data from audible
+			Client = license.LicenseDenialReasons?.FirstOrDefault(r => r.ValidationType == ValidationType.Client);
+			Ownership = license.LicenseDenialReasons?.FirstOrDefault(r => r.ValidationType == ValidationType.Ownership);
+			Membership = license.LicenseDenialReasons?.FirstOrDefault(r => r.ValidationType == ValidationType.Membership);
+			AYCL = license.LicenseDenialReasons?.FirstOrDefault(r => r.ValidationType == ValidationType.AYCL);
+		}
+	}
+}


### PR DESCRIPTION
Added a new Audible Api Exception: `ContentLicenseDeniedException`.

This exception uses regex to blank the customer ID so that this type of error may be logged in any logging level.