### PR TITLE
Add user review api

### DIFF
--- a/AudibleApi/Api [partial].cs
+++ b/AudibleApi/Api [partial].cs
@@ -33,7 +33,7 @@ namespace AudibleApi
 		public Task<HttpResponseMessage> AdHocAuthenticatedGetAsync(string requestUri, IHttpClientActions client)
 			=> AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Get, client);
 
-		public async Task<HttpResponseMessage> AdHocAuthenticatedRequestAsync(string requestUri, HttpMethod method, IHttpClientActions client, JObject postData = null)
+		public async Task<HttpResponseMessage> AdHocAuthenticatedRequestAsync(string requestUri, HttpMethod method, IHttpClientActions client, JObject requestBody = null)
 		{
 			if (requestUri is null)
 				throw new ArgumentNullException(nameof(requestUri));
@@ -41,13 +41,13 @@ namespace AudibleApi
 				throw new ArgumentException($"{nameof(requestUri)} may not be blank");
 			if (method is null)
 				throw new ArgumentNullException(nameof(method));
-			if (method.Method == HttpMethod.Post.Method && postData is null)
-				throw new ArgumentNullException(nameof(postData), $"Must provide post data when using {nameof(HttpMethod)}.{nameof(HttpMethod.Post)}");
+			if (requestBody is null && (method.Method == HttpMethod.Post.Method || method.Method == HttpMethod.Put.Method))
+				throw new ArgumentNullException(nameof(requestBody), $"Must provide request body content when using the {method.Method} {nameof(HttpMethod)}");
 
 			var request = new HttpRequestMessage(method, requestUri);
 
-			if (method.Method == HttpMethod.Post.Method)
-				request.AddContent(postData);
+			if (method.Method == HttpMethod.Post.Method || method.Method == HttpMethod.Put.Method)
+				request.AddContent(requestBody);
 
 			request.SignRequest(
 					_identityMaintainer.SystemDateTime.UtcNow,

--- a/AudibleApi/Api.Catalog.cs
+++ b/AudibleApi/Api.Catalog.cs
@@ -1,0 +1,72 @@
+﻿using Dinah.Core;
+using Dinah.Core.Net.Http;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace AudibleApi
+{
+	public partial class Api
+	{
+		public Task<bool> ReviewOverallAsync(string asin, int overallRating)
+			=> ReviewAsync(asin, overallRating, 0, 0);
+		public Task<bool> ReviewPerformanceAsync(string asin, int performanceRating)
+			=> ReviewAsync(asin, 0, performanceRating, 0);
+		public Task<bool> ReviewStoryAsync(string asin, int storyRating)
+			=> ReviewAsync(asin, 0, 0, storyRating);
+
+		public async Task<bool> ReviewAsync(string asin, int overall, int performance, int story)
+		{
+			const string requestUri = $"{CATALOG_PATH}/review";
+
+			ArgumentValidator.EnsureNotNullOrWhiteSpace(asin, nameof(asin));
+			ArgumentValidator.EnsureBetweenInclusive(overall, nameof(overall), 0, 5);
+			ArgumentValidator.EnsureBetweenInclusive(performance, nameof(performance), 0, 5);
+			ArgumentValidator.EnsureBetweenInclusive(story, nameof(story), 0, 5);
+
+			List<JObject> ratings = new();
+
+			if (overall != 0)
+				ratings.Add(new JObject { { "dimension", "overall" }, { "rating", overall } });
+			if (performance != 0)
+				ratings.Add(new JObject { { "dimension", "performance" }, { "rating", performance } });
+			if (story != 0)
+				ratings.Add(new JObject { { "dimension", "story" }, { "rating", story } });
+
+			if (ratings.Count == 0)
+				throw new ArgumentException($"At least one of {nameof(overall)}, {nameof(performance)}, or {nameof(story)} must be nonzero");
+
+			var body = new JObject()
+			{
+				{ "review",  new JObject
+					{
+						{ "asin", asin },
+						{ "rating_dimensions", JArray.FromObject(ratings) }
+					}
+				}
+			};
+
+			try
+			{
+				var response = await AdHocAuthenticatedRequestAsync(requestUri, HttpMethod.Put, Client, body);
+
+				var responseJobj = await response.Content.ReadAsJObjectAsync();
+
+				if (string.IsNullOrEmpty(responseJobj.Value<string>("review_id")))
+				{
+					Serilog.Log.Error("User review was not added {@DebugInfo}", responseJobj.ToString(Newtonsoft.Json.Formatting.None));
+					return false;
+				}
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Error(ex, "Error encountered while trying to set user rating.");
+				return false;
+			}
+		}
+	}
+}


### PR DESCRIPTION
I added user reviews to the api per https://github.com/mkb79/audible-cli/discussions/134.

This is for future use in Libation. I thought it'd be neat to allow reviewing books directly within Libation.

It works, and the reviews show up immediately in library scan.  Unlike when setting reviews on Audible.com, setting reviews through the api allows you to review books in your library that you haven't yet listened to. It even lets you review books you don't own.

![image](https://user-images.githubusercontent.com/37587114/210037816-95aff2b5-6602-46d8-a23e-f1e30e205558.png)
