### PR TITLE
Add more options and logging capabilities.

### DIFF
--- a/AudibleApi.Common/Converter.cs
+++ b/AudibleApi.Common/Converter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 
 namespace AudibleApi.Common
 {
@@ -24,6 +25,7 @@ namespace AudibleApi.Common
 
 		/// <summary>json => object using AudibleApi.Common serializers</summary>
 		public static T FromJson<T>(string json) => JsonConvert.DeserializeObject<T>(json, Settings);
+		public static T FromJson<T>(JObject json) => json.ToObject<T>(JsonSerializer.Create(Settings));
 
 		/// <summary>object => json using AudibleApi.Common serializers</summary>
 		public static string ToJson(object self) => JsonConvert.SerializeObject(self, Formatting.Indented, Settings);

--- a/AudibleApi.Common/DtoConverter.cs
+++ b/AudibleApi.Common/DtoConverter.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+
+namespace AudibleApi.Common
+{
+	internal class DtoConverter : JsonConverter
+	{
+		private bool skipNextMatch = false;
+		public override bool CanConvert(Type objectType)
+		{
+			if (objectType.IsAssignableTo(typeof(DtoBase)))
+			{
+				if (skipNextMatch)
+				{
+					skipNextMatch = false;
+					return false;
+				}
+				return true;
+			}
+			return false;
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var dtoJObject = JObject.Load(reader);
+
+			//We've already matched to the current dto type. Set skipNextMatch to true
+			//so that when ToObject() is called, this instance of JsonConverter will
+			//tell the serializer that it is not a match for the current data type and
+			//the serializer will move on. After a match is skipped, the skipNextMatch
+			//flag is reset to false so that any children members that are DtoBase will
+			//again be passed through this converter.
+			skipNextMatch = true;
+			var dto = dtoJObject.ToObject(objectType, serializer) as DtoBase;
+			dto.SourceJson = dtoJObject;
+
+			return dto;
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+			=> throw new NotImplementedException();
+	}
+}

--- a/AudibleApi.Common/LibraryDtoV10.cs
+++ b/AudibleApi.Common/LibraryDtoV10.cs
@@ -18,6 +18,7 @@
 // class Serialize: add partial
 // manually edited lots of enum stuff
 
+using Dinah.Core;
 using System;
 using System.Linq;
 
@@ -80,6 +81,37 @@ namespace AudibleApi.Common
 	public partial class Plan
 	{
 		public override string ToString() => $"{PlanName}";
+
+		/// <summary>
+		/// If a Book was added to the library as an Audible Plus book, <see cref="Item.IsAyce"/> is true regardless of whether
+		/// that title is still available for listening. To listen to it, you need rights under an Audible Plus or
+		/// Free Plan. If you don't have either of those plans, then the title will show as "Unavailable" in the
+		/// Audible library.
+		/// 
+		/// <para>Audible Plus Plan Names:</para>
+		/// <list type="bullet">
+		///		<item>
+		///			<term>US Minerva</term>
+		///			<description>US-only name</description>
+		///		</item>
+		///		<item>
+		///			<term>Audible-AYCL</term>
+		///			<description>Known to work for Italy, and India's Plan name contains "AYCL"</description>
+		///		</item>
+		/// </list>
+		/// <para>Other AYCE Plans:</para>
+		/// <list type="bullet">
+		///		<item>
+		///			<term>Free Tier</term>
+		///		</item>
+		///		<item>
+		///			<term>Ad Enabled Free Tier</term>
+		///		</item>
+		/// </list>
+		/// </summary>
+		public bool IsAyce => PlanName.ContainsInsensitive("Minerva") ||
+				PlanName.ContainsInsensitive("AYCL") ||
+				PlanName.ContainsInsensitive("Free");
 	}
 	public partial class Price
 	{

--- a/AudibleApi.Common/_DtoBase.cs
+++ b/AudibleApi.Common/_DtoBase.cs
@@ -1,10 +1,12 @@
-﻿using System;
+﻿using Newtonsoft.Json.Linq;
+using System;
 
 namespace AudibleApi.Common
 {
 	public abstract class DtoBase<T>
 	{
 		public static T FromJson(string json) => Converter.FromJson<T>(json);
+		public static T FromJson(JObject json) => Converter.FromJson<T>(json);
 		public string ToJson(T dto) => Converter.ToJson(dto);
 	}
 }

--- a/AudibleApi.Common/_DtoBase.cs
+++ b/AudibleApi.Common/_DtoBase.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using System;
 
 namespace AudibleApi.Common
@@ -9,7 +8,7 @@ namespace AudibleApi.Common
 		public JObject SourceJson { get; set; }
 	}
 
-	public abstract class DtoBase<T> : DtoBase where T : DtoBase<T>
+	public abstract class DtoBase<T> : DtoBase
 	{
 		public static T FromJson(string json) => FromJson(JObject.Parse(json));
 		public static T FromJson(JObject json) => Converter.FromJson<T>(json);

--- a/AudibleApi.Common/_DtoBase.cs
+++ b/AudibleApi.Common/_DtoBase.cs
@@ -1,11 +1,17 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 
 namespace AudibleApi.Common
 {
-	public abstract class DtoBase<T>
+	public abstract class DtoBase
 	{
-		public static T FromJson(string json) => Converter.FromJson<T>(json);
+		public JObject SourceJson { get; set; }
+	}
+
+	public abstract class DtoBase<T> : DtoBase where T : DtoBase<T>
+	{
+		public static T FromJson(string json) => FromJson(JObject.Parse(json));
 		public static T FromJson(JObject json) => Converter.FromJson<T>(json);
 		public string ToJson(T dto) => Converter.ToJson(dto);
 	}

--- a/AudibleApi.Common/_V10Base.cs
+++ b/AudibleApi.Common/_V10Base.cs
@@ -3,8 +3,8 @@ using Newtonsoft.Json;
 
 namespace AudibleApi.Common
 {
-	public abstract class V10Base<T> : DtoBase<T>
-    {
+	public abstract class V10Base<T> : DtoBase<T> where T : DtoBase<T>
+	{
         [JsonProperty("response_groups")]
         public string[] ResponseGroups { get; set; }
 

--- a/AudibleApi.Common/_V10Base.cs
+++ b/AudibleApi.Common/_V10Base.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace AudibleApi.Common
 {
-	public abstract class V10Base<T> : DtoBase<T> where T : DtoBase<T>
+	public abstract class V10Base<T> : DtoBase<T>
 	{
         [JsonProperty("response_groups")]
         public string[] ResponseGroups { get; set; }

--- a/AudibleApi/Api.Download.cs
+++ b/AudibleApi/Api.Download.cs
@@ -14,7 +14,14 @@ namespace AudibleApi
         High,
         Normal
     }
-    public partial class Api
+
+    public enum ChapterTitlesType
+    {
+        Flat,
+        Tree
+    }
+
+	public partial class Api
     {
 		#region Download License
 
@@ -28,7 +35,7 @@ namespace AudibleApi
 		/// <exception cref="InvalidResponseException">Thrown when the Api did not return a proper <see cref="ContentLicense"/>.</exception>
 		/// <exception cref="InvalidValueException">Thrown when <see cref="ContentLicense.StatusCode"/> is not "Granted" or "Denied".</exception>
 		/// <exception cref="ContentLicenseDeniedException">Thrown when <see cref="ContentLicense.StatusCode"/> is "Denied".</exception>
-		public async Task<ContentLicense> GetDownloadLicenseAsync(string asin, DownloadQuality quality = DownloadQuality.High)
+		public async Task<ContentLicense> GetDownloadLicenseAsync(string asin, DownloadQuality quality = DownloadQuality.High, ChapterTitlesType chapterTitlesType = ChapterTitlesType.Tree)
         {
             ArgumentValidator.EnsureNotNullOrWhiteSpace(asin, nameof(asin));
 
@@ -37,6 +44,7 @@ namespace AudibleApi
                 { "consumption_type", "Download" },
                 { "supported_drm_types", new JArray{ "Adrm", "Mpeg" } },
                 { "quality", quality.ToString() },
+                { "chapter_titles_type", chapterTitlesType.ToString() },
                 { "response_groups", "last_position_heard,pdf_url,content_reference,chapter_info"}
             };
 

--- a/AudibleApi/Api.Library.cs
+++ b/AudibleApi/Api.Library.cs
@@ -13,14 +13,14 @@ namespace AudibleApi
 {
 	public class LibraryOptions
 	{
-		public const int NUMBER_OF_RESULTS_PER_PAGE_MIN = 0;
+		public const int NUMBER_OF_RESULTS_PER_PAGE_MIN = 1;
 		public const int NUMBER_OF_RESULTS_PER_PAGE_MAX = 1000;
 
 		private int? _numResults;
 		public int? NumberOfResultPerPage
 		{
 			get => _numResults;
-            set => _numResults
+			set => _numResults
 				= value is null
 				? null
 				: ArgumentValidator.EnsureBetweenInclusive(value.Value, nameof(value), NUMBER_OF_RESULTS_PER_PAGE_MIN, NUMBER_OF_RESULTS_PER_PAGE_MAX);
@@ -182,6 +182,7 @@ namespace AudibleApi
 	{
 		const string LIBRARY_PATH = "/1.0/library";
 
+
 		#region GetLibraryAsync
 		public Task<JObject> GetLibraryAsync()
 			=> getLibraryAsync(new LibraryOptions { PurchasedAfter = new DateTime(1970, 1, 1) }.ToQueryString());
@@ -271,53 +272,95 @@ namespace AudibleApi
 					ImageSizes = LibraryOptions.ImageSizeOptions._500 | LibraryOptions.ImageSizeOptions._1215
 				});
 
-		public async Task<List<Item>> GetAllLibraryItemsAsync(LibraryOptions.ResponseGroupOptions responseGroups)
-			=> await getAllLibraryItemsAsync_gated(new LibraryOptions { ResponseGroups = responseGroups });
-
-		public async Task<List<Item>> GetAllLibraryItemsAsync(LibraryOptions libraryOptions)
-			=> await getAllLibraryItemsAsync_gated(libraryOptions);
+		public Task<List<Item>> GetAllLibraryItemsAsync(LibraryOptions.ResponseGroupOptions responseGroups, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+			=> GetAllLibraryItemsAsync(new LibraryOptions { ResponseGroups = responseGroups }, numItemsPerRequest, maxConcurrentRequests);
 		
+		public Task<List<Item>> GetAllLibraryItemsAsync(LibraryOptions.ResponseGroupOptions responseGroups, int numItemsPerRequest, SemaphoreSlim semaphore)
+			=> GetAllLibraryItemsAsync(new LibraryOptions { ResponseGroups = responseGroups }, numItemsPerRequest, semaphore);
+
+		public async Task<List<Item>> GetAllLibraryItemsAsync(LibraryOptions libraryOptions, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+		{
+			using var semaphoreSlim = new SemaphoreSlim(maxConcurrentRequests);
+
+			return await GetAllLibraryItemsAsync(libraryOptions, numItemsPerRequest, semaphoreSlim);
+		}
+
+		public async Task<List<Item>> GetAllLibraryItemsAsync(LibraryOptions libraryOptions, int numItemsPerRequest, SemaphoreSlim semaphore)
+		{
+			var allItems = new List<Item>();
+
+			await foreach (var items in GetLibraryItemsPagesAsync(libraryOptions, numItemsPerRequest, semaphore))
+				allItems.AddRange(items);
+
+			return allItems;
+		}
+
 		public async IAsyncEnumerable<Item> GetLibraryItemAsyncEnumerable(LibraryOptions libraryOptions, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+		{
+			await foreach (var page in GetLibraryItemsPagesAsync(libraryOptions, numItemsPerRequest, maxConcurrentRequests))
+				foreach (var item in page)
+					yield return item;
+		}
+
+		public async IAsyncEnumerable<Item> GetLibraryItemAsyncEnumerable(LibraryOptions libraryOptions, int numItemsPerRequest, SemaphoreSlim semaphore)
+		{
+			await foreach (var page in GetLibraryItemsPagesAsync(libraryOptions, numItemsPerRequest, semaphore))
+				foreach (var item in page)
+					yield return item;
+		}
+
+		public async IAsyncEnumerable<Item[]> GetLibraryItemsPagesAsync(LibraryOptions libraryOptions, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+		{
+			using var semaphore = new SemaphoreSlim(maxConcurrentRequests);
+
+			await foreach (var item in GetLibraryItemsPagesAsync(libraryOptions, numItemsPerRequest, semaphore))
+				yield return item;
+		}
+
+		public async IAsyncEnumerable<Item[]> GetLibraryItemsPagesAsync(LibraryOptions libraryOptions, int numItemsPerRequest, SemaphoreSlim semaphore)
 		{
 			if (!libraryOptions.PurchasedAfter.HasValue || libraryOptions.PurchasedAfter.Value < new DateTime(1970, 1, 1))
 				libraryOptions.PurchasedAfter = new DateTime(1970, 1, 1);
-			
+
 			libraryOptions.NumberOfResultPerPage = numItemsPerRequest;
-			
-			int totalCount = await GetItemsCountAsync(libraryOptions);
-			
-			int numPages = totalCount / libraryOptions.NumberOfResultPerPage.Value;
-			if (numPages * libraryOptions.NumberOfResultPerPage.Value < totalCount)
-				numPages++;
 
-			List<Task<Item[]>> allDlTasks = new();
-			using SemaphoreSlim concurrencySemaphore = new(maxConcurrentRequests);
+			List<Task<LibraryDtoV10>> pageDlTasks = new();
 
-			for (int page = 1; page <= numPages; page++)
+			int page = 0;
+			int totalItems = await GetItemsCountAsync(libraryOptions);
+			int totalPages = totalItems / numItemsPerRequest;
+			if (totalPages * numItemsPerRequest < totalItems) totalPages++;
+
+			//Spin up as many concurrent downloads as we can/need
+			while (semaphore.CurrentCount > 0 && page < totalPages)
+				spinupPageRequest();
+
+			while (pageDlTasks.Count > 0)
 			{
-				libraryOptions.PageNumber = page;
-				var queryString = libraryOptions.ToQueryString();
+				var completed = await Task.WhenAny(pageDlTasks);
+				pageDlTasks.Remove(completed);
 
-				allDlTasks.Add(downloadItemPage(concurrencySemaphore, queryString, page));
+				//Request a new page.
+				if (page < totalPages) spinupPageRequest();
+
+				yield return completed.Result.Items;
 			}
 
-			while (allDlTasks.Count > 0)
+			async void spinupPageRequest()
 			{
-				var completed = await Task.WhenAny(allDlTasks);
-				allDlTasks.Remove(completed);
-				foreach (var item in completed.Result)
-					yield return item;
+				libraryOptions.PageNumber = ++page;
+				await semaphore.WaitAsync();
+				pageDlTasks.Add(downloadItemPage(semaphore, libraryOptions.ToQueryString(), page));
 			}
 		}
 
-		private async Task<Item[]> downloadItemPage(SemaphoreSlim concurrencySemaphore, string queryString, int pageNumber)
+		private async Task<LibraryDtoV10> downloadItemPage(SemaphoreSlim semaphore, string queryString, int pageNumber)
 		{
-			await concurrencySemaphore.WaitAsync();
 			try
 			{
-				var response = await getLibraryResponseAsync($"{queryString}");
+				var response = await getLibraryResponseAsync(queryString);
+				var page = await response.Content.ReadAsJObjectAsync();
 
-				var page = await response.Content.ReadAsStringAsync();
 				LibraryDtoV10 libResult;
 				try
 				{
@@ -326,19 +369,18 @@ namespace AudibleApi
 				}
 				catch (Exception ex)
 				{
-					Serilog.Log.Logger.Error(ex, "Error converting library for importing use. Full library:\r\n" + page);
+					Serilog.Log.Logger.Error(ex, "Error converting library for importing use. Full library:\r\n" + page.ToString(Newtonsoft.Json.Formatting.None));
 					throw;
 				}
 
 				Serilog.Log.Logger.Information($"Page {pageNumber}: {libResult.Items.Length} results");
-				return libResult.Items;
+				return libResult;
 			}
-			finally
-			{
-				concurrencySemaphore.Release();
-			}
+			finally { semaphore.Release(); }
 		}
 
+
+		/// <summary>Gets the total number of Items in the account's library</summary>
 		public async Task<int> GetItemsCountAsync(LibraryOptions libraryOptions)
 		{
 			var orig = libraryOptions.NumberOfResultPerPage;
@@ -358,80 +400,6 @@ namespace AudibleApi
 			{
 				libraryOptions.NumberOfResultPerPage = orig;
 			}
-		}
-
-		private async Task<List<Item>> getAllLibraryItemsAsync_gated(LibraryOptions libraryOptions)
-        {
-			if (!libraryOptions.PurchasedAfter.HasValue || libraryOptions.PurchasedAfter.Value < new DateTime(1970, 1, 1))
-				libraryOptions.PurchasedAfter = new DateTime(1970, 1, 1);
-
-			try
-            {
-                // max 1000 however with higher numbers it stops returning 'provided_review' and 'reviews' groups.
-                // Sometimes this threshold is as high as 900, sometimes as low as 400.
-                // I've never had problems at 300. Another user had nearly constant problems at 300.
-                libraryOptions.NumberOfResultPerPage = 250;
-                return await getAllLibraryItemsAsync_internal(libraryOptions);
-            }
-            catch (Exception ex) when (ex is TaskCanceledException || ex is TimeoutException)
-            {
-                // if it times out with 250, try 50. This takes about 5 seconds longer for a library of 1,100
-                //
-                // For each batch size, I ran 3 tests. Results in milliseconds
-                //   1000    19389 , 17760 , 19256
-                //    500    19099 , 19905 , 18553
-                //    250    20288 , 19163 , 19605
-                //    100    22156 , 22058 , 22438
-                //     50    25017 , 24292 , 24491
-                //     25    28627 , 30006 , 31201
-                //     10    45006 , 46717 , 44924
-                libraryOptions.NumberOfResultPerPage = 50;
-                return await getAllLibraryItemsAsync_internal(libraryOptions);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
-        }
-
-		private async Task<List<Item>> getAllLibraryItemsAsync_internal(LibraryOptions libraryOptions)
-		{
-			var allItems = new List<Item>();
-
-			for (var pageNumber = 1; ; pageNumber++)
-			{
-				// if attempting to paginate more than 10,000 titles : {"error_code":null,"message":"Implied library size is unsupported"}"
-				if (pageNumber * libraryOptions.NumberOfResultPerPage > 10000)
-				{
-					Serilog.Log.Logger.Information($"Maximum reached. Cannot retrieve more than 10,000 titles");
-					break;
-				}
-
-				libraryOptions.PageNumber = pageNumber;
-				var page = await GetLibraryAsync(libraryOptions);
-
-				var pageStr = page.ToString();
-
-				LibraryDtoV10 libResult;
-				try
-				{
-					// important! use this convert/deser method
-					libResult = LibraryDtoV10.FromJson(pageStr);
-				}
-				catch (Exception ex)
-				{
-					Serilog.Log.Logger.Error(ex, "Error converting library for importing use. Full library:\r\n" + pageStr);
-					throw;
-				}
-
-				if (!libResult.Items.Any())
-					break;
-
-				Serilog.Log.Logger.Information($"Page {pageNumber}: {libResult.Items.Length} results");
-				allItems.AddRange(libResult.Items);
-			}
-
-			return allItems;
 		}
 		#endregion
 	}

--- a/AudibleApi/Api.Library.cs
+++ b/AudibleApi/Api.Library.cs
@@ -244,20 +244,8 @@ namespace AudibleApi
 			if (!string.IsNullOrWhiteSpace(responseGroups))
 				url += "?" + responseGroups;
 			var response = await AdHocAuthenticatedGetAsync(url);
-			var obj = await response.Content.ReadAsJObjectAsync();
-			var objStr = obj.ToString();
 
-			BookDtoV10 dto;
-			try
-			{
-				// important! use this convert/deser method
-				dto = BookDtoV10.FromJson(objStr);
-			}
-			catch (Exception ex)
-			{
-				Serilog.Log.Logger.Error(ex, "Error converting catalog product. Full json:\r\n" + objStr);
-				throw;
-			}
+			BookDtoV10 dto = await response.Content.ReadAsDtoAsync<BookDtoV10>();
 
 			return dto.Item;
 		}
@@ -359,19 +347,8 @@ namespace AudibleApi
 			try
 			{
 				var response = await getLibraryResponseAsync(queryString);
-				var page = await response.Content.ReadAsJObjectAsync();
 
-				LibraryDtoV10 libResult;
-				try
-				{
-					// important! use this convert/deser method
-					libResult = LibraryDtoV10.FromJson(page);
-				}
-				catch (Exception ex)
-				{
-					Serilog.Log.Logger.Error(ex, "Error converting library for importing use. Full library:\r\n" + page.ToString(Newtonsoft.Json.Formatting.None));
-					throw;
-				}
+				var	libResult = await response.Content.ReadAsDtoAsync<LibraryDtoV10>();
 
 				Serilog.Log.Logger.Information($"Page {pageNumber}: {libResult.Items.Length} results");
 				return libResult;

--- a/AudibleApi/Api.Records.cs
+++ b/AudibleApi/Api.Records.cs
@@ -106,10 +106,14 @@ namespace AudibleApi
 			{
 				var client = Sharer.GetSharedHttpClient(FIONA_DOMAIN);
 				var response = await AdHocAuthenticatedGetAsync(requestUri, client);
-				var responseContent = await response.Content.ReadAsStringAsync();
+				if (response.IsSuccessStatusCode)
+				{
+					var recordDto = await response.Content.ReadAsDtoAsync<RecordDto>();
+					return recordDto?.Payload?.Records;
 
-				//Response is 404 if book has no records
-				return response.IsSuccessStatusCode ? RecordDto.FromJson(responseContent)?.Payload?.Records ?? new() : new();
+				}
+				else
+					return new(); //Response is 404 if book has no records				
 			}
 			catch (Exception ex)
 			{

--- a/AudibleApi/ApiUnauthenticated.Catalog.cs
+++ b/AudibleApi/ApiUnauthenticated.Catalog.cs
@@ -113,19 +113,7 @@ namespace AudibleApi
 			if (!string.IsNullOrWhiteSpace(options))
 				url += "?" + options;
 			var response = await AdHocNonAuthenticatedGetAsync(url);
-			var objStr = await response.Content.ReadAsStringAsync();
-
-			ProductsDtoV10 dto;
-			try
-			{
-				// important! use this convert/deser method
-				dto = ProductsDtoV10.FromJson(objStr);
-			}
-			catch (Exception ex)
-			{
-				Serilog.Log.Logger.Error(ex, "Error converting catalog product. Full json:\r\n" + objStr);
-				throw;
-			}
+			var dto = await response.Content.ReadAsDtoAsync<ProductsDtoV10>();			
 
 			return dto.Products.ToList();
 		}

--- a/AudibleApi/ApiUnauthenticated.Content.cs
+++ b/AudibleApi/ApiUnauthenticated.Content.cs
@@ -16,18 +16,8 @@ namespace AudibleApi
 			var url = $"{CONTENT_PATH}/{asin}/metadata?response_groups=chapter_info,content_reference&chapter_titles_type={chapterTitlesType}";
 
 			var response = await AdHocNonAuthenticatedGetAsync(url);
-			var metadataJson = await response.Content.ReadAsStringAsync();
-
-			MetadataDtoV10 contentMetadata;
-			try
-			{
-				contentMetadata = MetadataDtoV10.FromJson(metadataJson);
-			}
-			catch (Exception ex)
-			{
-				Serilog.Log.Logger.Error(ex, $"Error retrieving content metadata for asin: {asin}");
-				throw;
-			}
+			var contentMetadata = await response.Content.ReadAsDtoAsync<MetadataDtoV10>();
+			
 			return contentMetadata?.ContentMetadata;
 		}
 	}

--- a/AudibleApi/ApiUnauthenticated.Content.cs
+++ b/AudibleApi/ApiUnauthenticated.Content.cs
@@ -9,11 +9,11 @@ namespace AudibleApi
     public partial class ApiUnauthenticated
 	{
         protected const string CONTENT_PATH = "/1.0/content";
-		public async Task<ContentMetadata> GetContentMetadataAsync(string asin)
+		public async Task<ContentMetadata> GetContentMetadataAsync(string asin, ChapterTitlesType chapterTitlesType = ChapterTitlesType.Tree)
 		{
 			asin = ArgumentValidator.EnsureNotNullOrWhiteSpace(asin, nameof(asin)).ToUpper().Trim();
 
-			var url = $"{CONTENT_PATH}/{asin}/metadata?response_groups=chapter_info,content_reference";
+			var url = $"{CONTENT_PATH}/{asin}/metadata?response_groups=chapter_info,content_reference&chapter_titles_type={chapterTitlesType}";
 
 			var response = await AdHocNonAuthenticatedGetAsync(url);
 			var metadataJson = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
# [Add ChapterTitlesType option](https://github.com/rmcrackan/AudibleApi/commit/5bae3cdbc48983ea3094ee201eaab58bdfb94446)
I discovered an option for how Audible returns chapter info. You can request "Flat" (the old default format) or "Tree", the new default format.

# [Add support to deserialiaze JObject to object](https://github.com/rmcrackan/AudibleApi/commit/0f57b0676be3819e7dc681e537b74b587f54207d)

Just a quality of life method for converting `JObject` to a .NET object without having to convert to string first.

# [Add IsAyce property to Plans](https://github.com/rmcrackan/AudibleApi/commit/715207016805d08cad93735729982c5ddfcd5257)

This is how we detect if a book has any free/plus plans from within Libation. I thought it would be nice to have as a Plan property.

# [Unify Library Api requests](https://github.com/rmcrackan/AudibleApi/commit/1c720284b357466b1225207cb81e8b4d42eedaa4)

I added several more methods for scanning the library, and they all use the `GetLibraryItemsPagesAsync` which returns an `IAsyncEnumerable<Item[]>`. I plan to use these to improve concurrent scan performance in Libation.

# [Add ISourceJson and ReadAsDtoAsync<T>()](https://github.com/rmcrackan/AudibleApi/pull/40/commits/ddd9681eae95caf679fde0cb3030aa5a67983f6b)

There are a couple of things in here:
-  Added `ReadAsDtoAsync<T>()` to read and parse a Dto directly from `HttpContent`. It also takes care of logging errors.
- Added `DtoBase` class with property `SourceJson`. Objects that are `DtoBase` will have their source JObject saved to `DtoBase.SourceJson`.