### PR TITLE
Add support for concurrent catalog requests and bugfix

### DIFF
--- a/AudibleApi.Common/Item.cs
+++ b/AudibleApi.Common/Item.cs
@@ -30,6 +30,8 @@ namespace AudibleApi.Common
 		public int MyUserRating_Performance => Convert.ToInt32(ProvidedReview?.Ratings?.PerformanceRating ?? 0L);
 		public int MyUserRating_Story => Convert.ToInt32(ProvidedReview?.Ratings?.StoryRating ?? 0L);
 
+		/// <summary>Indicates if this item may be added to the user's library.</summary>
+		public bool CanAddToLibrary => Price is not null;
 		public bool IsAbridged => FormatType == AudibleApi.Common.FormatType.Abridged;
 		public DateTime? DatePublished => IssueDate?.UtcDateTime; // item.IssueDate == item.ReleaseDate
 		public string Publisher => PublisherName;

--- a/AudibleApi/Api.Library.cs
+++ b/AudibleApi/Api.Library.cs
@@ -319,22 +319,24 @@ namespace AudibleApi
 			int totalPages = totalItems / numItemsPerRequest;
 			if (totalPages * numItemsPerRequest < totalItems) totalPages++;
 
-			//Spin up as many concurrent downloads as we can/need
-			while (semaphore.CurrentCount > 0 && page < totalPages)
-				spinupPageRequest();
+			//Spin up as many concurrent downloads as we can/need. Minimum 1.
+			do
+				await spinupPageRequest();
+			while (semaphore.CurrentCount > 0 && page < totalPages);
 
 			while (pageDlTasks.Count > 0)
 			{
 				var completed = await Task.WhenAny(pageDlTasks);
 				pageDlTasks.Remove(completed);
 
-				//Request a new page.
-				if (page < totalPages) spinupPageRequest();
+				//Request new page(s)
+				while (semaphore.CurrentCount > 0 && page < totalPages)
+					await spinupPageRequest();
 
 				yield return completed.Result.Items;
 			}
 
-			async void spinupPageRequest()
+			async Task spinupPageRequest()
 			{
 				libraryOptions.PageNumber = ++page;
 				await semaphore.WaitAsync();

--- a/AudibleApi/Api.Library.cs
+++ b/AudibleApi/Api.Library.cs
@@ -321,7 +321,7 @@ namespace AudibleApi
 
 			//Spin up as many concurrent downloads as we can/need. Minimum 1.
 			do
-				await spinupPageRequest();
+				await spinupPageRequestAsync();
 			while (semaphore.CurrentCount > 0 && page < totalPages);
 
 			while (pageDlTasks.Count > 0)
@@ -331,12 +331,12 @@ namespace AudibleApi
 
 				//Request new page(s)
 				while (semaphore.CurrentCount > 0 && page < totalPages)
-					await spinupPageRequest();
+					await spinupPageRequestAsync();
 
 				yield return completed.Result.Items;
 			}
 
-			async Task spinupPageRequest()
+			async Task spinupPageRequestAsync()
 			{
 				libraryOptions.PageNumber = ++page;
 				await semaphore.WaitAsync();

--- a/AudibleApi/ApiUnauthenticated.Catalog.cs
+++ b/AudibleApi/ApiUnauthenticated.Catalog.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using AudibleApi.Common;
 using Dinah.Core;
@@ -97,25 +98,123 @@ namespace AudibleApi
 	public partial class ApiUnauthenticated
 	{
 		protected const string CATALOG_PATH = "/1.0/catalog";
+		public const int MaxAsinsPerRequest = 50;
+
 
 		public async Task<Item> GetCatalogProductAsync(string asin, CatalogOptions.ResponseGroupOptions responseGroups)
-			=> (await GetCatalogProductsAsync(new CatalogOptions { ResponseGroups = responseGroups, Asins = new() { asin } })).Single();
+			=> (await GetCatalogProductsAsync(new[] { asin }, responseGroups)).Single();
 
-		public Task<List<Item>> GetCatalogProductsAsync(IEnumerable<string> asins, CatalogOptions.ResponseGroupOptions responseGroups)
-			=> GetCatalogProductsAsync(new CatalogOptions { ResponseGroups = responseGroups, Asins = asins.ToList() });
-
-		public async Task<List<Item>> GetCatalogProductsAsync(CatalogOptions catalogOptions)
+		public async Task<List<Item>> GetCatalogProductsAsync(IEnumerable<string> asins, CatalogOptions.ResponseGroupOptions responseGroups)
 		{
-			var options = ArgumentValidator.EnsureNotNull(catalogOptions, nameof(catalogOptions)).ToQueryString();
-			options = options?.Trim().Trim('?');
+			var options = new CatalogOptions
+			{
+				ResponseGroups = responseGroups,
+				Asins = asins.ToList()
+			};
 
-			var url = $"{CATALOG_PATH}/products/";
-			if (!string.IsNullOrWhiteSpace(options))
-				url += "?" + options;
-			var response = await AdHocNonAuthenticatedGetAsync(url);
-			var dto = await response.Content.ReadAsDtoAsync<ProductsDtoV10>();			
-
+			var dto = await getCatalogPageAsync(null, options);
 			return dto.Products.ToList();
+		}
+
+		public async Task<List<Item>> GetCatalogProductsAsync(IEnumerable<string> asins, CatalogOptions.ResponseGroupOptions responseGroups, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+		{
+			using var semaphoreSlim = new SemaphoreSlim(maxConcurrentRequests);
+
+			return await GetCatalogProductsAsync(asins, responseGroups, numItemsPerRequest, semaphoreSlim);
+		}
+
+		public async Task<List<Item>> GetCatalogProductsAsync(IEnumerable<string> asins, CatalogOptions.ResponseGroupOptions responseGroups, int numItemsPerRequest, SemaphoreSlim semaphore)
+		{
+			var allItems = new List<Item>();
+
+			await foreach (var items in GetCatalogPagesAsync(asins, responseGroups, numItemsPerRequest, semaphore))
+				allItems.AddRange(items);
+
+			return allItems;
+		}
+
+		public async IAsyncEnumerable<Item> GetCatalogProductsAsyncEnumerable(IEnumerable<string> asins, CatalogOptions.ResponseGroupOptions responseGroups, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+		{
+			await foreach (var page in GetCatalogPagesAsync(asins, responseGroups, numItemsPerRequest, maxConcurrentRequests))
+				foreach (var item in page)
+					yield return item;
+		}
+
+		public async IAsyncEnumerable<Item> GetCatalogProductsAsyncEnumerable(IEnumerable<string> asins, CatalogOptions.ResponseGroupOptions responseGroups, int numItemsPerRequest, SemaphoreSlim semaphore)
+		{
+			await foreach (var page in GetCatalogPagesAsync(asins, responseGroups, numItemsPerRequest, semaphore))
+				foreach (var item in page)
+					yield return item;
+		}
+
+		public async IAsyncEnumerable<Item[]> GetCatalogPagesAsync(IEnumerable<string> asins, CatalogOptions.ResponseGroupOptions responseGroups, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+		{
+			using var semaphore = new SemaphoreSlim(maxConcurrentRequests);
+
+			await foreach (var item in GetCatalogPagesAsync(asins, responseGroups, numItemsPerRequest, semaphore))
+				yield return item;
+		}
+
+		public async IAsyncEnumerable<Item[]> GetCatalogPagesAsync(IEnumerable<string> asins, CatalogOptions.ResponseGroupOptions responseGroups, int numItemsPerRequest, SemaphoreSlim semaphore)
+		{
+			var asinList = ArgumentValidator.EnsureNotNull(asins, nameof(asins)).ToList();
+			ArgumentValidator.EnsureGreaterThan(asinList.Count, nameof(asinList), 0);
+			ArgumentValidator.EnsureBetweenInclusive(numItemsPerRequest, nameof(numItemsPerRequest), 1, MaxAsinsPerRequest);
+
+			List<Task<ProductsDtoV10>> pageDlTasks = new();
+
+			int page = 0;
+			int totalItems = asins.Count();
+			int totalPages = totalItems / numItemsPerRequest;
+			if (totalPages * numItemsPerRequest < totalItems) totalPages++;
+
+			//Spin up as many concurrent downloads as we can/need. Minimum 1.
+			do
+				await spinupPageRequest();
+			while (semaphore.CurrentCount > 0 && page < totalPages);
+
+			while (pageDlTasks.Count > 0)
+			{
+				var completed = await Task.WhenAny(pageDlTasks);
+				pageDlTasks.Remove(completed);
+
+				//Request new page(s).
+				while (semaphore.CurrentCount > 0 && page < totalPages)
+					await spinupPageRequest();
+
+				yield return completed.Result.Products;
+			}
+
+			async Task spinupPageRequest()
+			{
+				var options = new CatalogOptions
+				{
+					ResponseGroups = responseGroups,
+					Asins = asinList.Skip(page * numItemsPerRequest).Take(numItemsPerRequest).ToList()
+				};
+				await semaphore.WaitAsync();
+				pageDlTasks.Add(getCatalogPageAsync(semaphore, options));
+				page++;
+			}
+		}
+
+		protected virtual async Task<ProductsDtoV10> getCatalogPageAsync(SemaphoreSlim semaphore, CatalogOptions catalogOptions)
+		{
+			try
+			{
+				ArgumentValidator.EnsureBetweenInclusive(catalogOptions.Asins.Count, $"{nameof(catalogOptions)}.Asins.Count", 1, MaxAsinsPerRequest);
+				var options = ArgumentValidator.EnsureNotNull(catalogOptions, nameof(catalogOptions)).ToQueryString();
+				options = options?.Trim().Trim('?');
+
+				var url = $"{CATALOG_PATH}/products/";
+				if (!string.IsNullOrWhiteSpace(options))
+					url += "?" + options;
+				var response = await AdHocNonAuthenticatedGetAsync(url);
+				var dto = await response.Content.ReadAsDtoAsync<ProductsDtoV10>();
+
+				return dto;
+			}
+			finally { semaphore?.Release(); }
 		}
 	}
 }

--- a/AudibleApi/ApiUnauthenticated.Catalog.cs
+++ b/AudibleApi/ApiUnauthenticated.Catalog.cs
@@ -170,7 +170,7 @@ namespace AudibleApi
 
 			//Spin up as many concurrent downloads as we can/need. Minimum 1.
 			do
-				await spinupPageRequest();
+				await spinupPageRequestAsync();
 			while (semaphore.CurrentCount > 0 && page < totalPages);
 
 			while (pageDlTasks.Count > 0)
@@ -180,12 +180,12 @@ namespace AudibleApi
 
 				//Request new page(s).
 				while (semaphore.CurrentCount > 0 && page < totalPages)
-					await spinupPageRequest();
+					await spinupPageRequestAsync();
 
 				yield return completed.Result.Products;
 			}
 
-			async Task spinupPageRequest()
+			async Task spinupPageRequestAsync()
 			{
 				var options = new CatalogOptions
 				{


### PR DESCRIPTION
- Fixed a bug in the library scan where the async `spinupPageRequest` wasn't being awaited. For the life of me I don't know how I a) screwed that up in the first place and b) received responses to all my requests without dropping any.

- Added a bunch of new mnethods to get products from catalog. The catalog methods now look almost identical to the library methods. 

- Added an authenticated override to `getCatalogPageAsync`, so when using the authenticated api the catalog requests are authenticated.