### PR TITLE
 Attempt to fix NRE and add methods to add/remove books from library

### DIFF
--- a/AudibleApi/Authorization/Identity [partial].cs
+++ b/AudibleApi/Authorization/Identity [partial].cs
@@ -69,7 +69,7 @@ namespace AudibleApi.Authorization
 			LocaleName = ArgumentValidator.EnsureNotNull(locale, nameof(locale)).Name;
 			Authorization = ArgumentValidator.EnsureNotNull(authorization, nameof(authorization));
 			ExistingAccessToken = AccessToken.Empty;
-			_cookies = ArgumentValidator.EnsureNotNull(cookies, nameof(cookies)).ToList();
+			_cookies = cookies?.ToList() ?? new();
 		}
 
 		public void Update(AccessToken accessToken)
@@ -85,7 +85,7 @@ namespace AudibleApi.Authorization
 			ExistingAccessToken = ArgumentValidator.EnsureNotNull(accessToken, nameof(accessToken));
 			RefreshToken = ArgumentValidator.EnsureNotNull(refreshToken, nameof(refreshToken));
 
-			_cookies = cookies?.ToList();
+			_cookies = cookies?.ToList() ?? new();
 
 			DeviceSerialNumber = deviceSerialNumber ?? string.Empty;
 			DeviceType = deviceType ?? string.Empty;

--- a/AudibleApi/RestMessageValidator.cs
+++ b/AudibleApi/RestMessageValidator.cs
@@ -49,7 +49,7 @@ namespace AudibleApi
                 throw new ApiErrorException(requestUri, jObject, error);
             }
 
-            if (jObject.TryGetValue("error_code", out JToken errorCodeToken))
+            if (jObject.TryGetValue("error_code", out JToken errorCodeToken) && errorCodeToken.Type is not JTokenType.Null)
             {
                 var error = errorCodeToken.ToString();
                 throw new ApiErrorException(requestUri, jObject, error);


### PR DESCRIPTION
# [Add support for addind and removing AYCL items from the library](https://github.com/rmcrackan/AudibleApi/commit/211099598e6aa4a8c829fdb706389d4e28c37a8c)

These methods are currently unused by Libation, but they've been working great.

[Attempt to](https://github.com/rmcrackan/AudibleApi/commit/2ef1d13c283cfff13aee4b89f3afa4c51f47b976) [fix](https://github.com/rmcrackan/AudibleApi/commit/2ef1d13c283cfff13aee4b89f3afa4c51f47b976) https://github.com/rmcrackan/Libation/issues/532

I hope that's all of the cookie locations. Can you think of any other places the identity stores/uses cookies?