### PR TITLE
Add WishList methods

### DIFF
--- a/AudibleApi.Common/WishListDtoV10.cs
+++ b/AudibleApi.Common/WishListDtoV10.cs
@@ -1,0 +1,6 @@
+﻿namespace AudibleApi.Common
+{
+	public partial class WishListDtoV10 : V10Base<WishListDtoV10>
+	{
+	}
+}

--- a/AudibleApi.Common/WishListDtoV10.generated.cs
+++ b/AudibleApi.Common/WishListDtoV10.generated.cs
@@ -1,0 +1,173 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace AudibleApi.Common
+{
+	public partial class WishListDtoV10
+	{
+		[JsonProperty("bin_fields")]
+		public object BinFields { get; set; }
+
+		[JsonProperty("products")]
+		public Product[] Products { get; set; }
+
+		[JsonProperty("total_results")]
+		public int TotalResults { get; set; }
+	}
+
+	public partial class Product : DtoBase<Product>
+	{
+		[JsonProperty("added_timestamp")]
+		public DateTimeOffset AddedTimestamp { get; set; }
+
+		[JsonProperty("asin")]
+		public string Asin { get; set; }
+
+		[JsonProperty("audible_editors_summary")]
+		public string AudibleEditorsSummary { get; set; }
+
+		[JsonProperty("authors")]
+		public Author[] Authors { get; set; }
+
+		[JsonProperty("available_codecs")]
+		public AvailableCodec[] AvailableCodecs { get; set; }
+
+		[JsonProperty("content_delivery_type")]
+		public string ContentDeliveryType { get; set; }
+
+		[JsonProperty("content_type")]
+		public string ContentType { get; set; }
+
+		[JsonProperty("customer_rights")]
+		public CustomerRights CustomerRights { get; set; }
+
+		[JsonProperty("distribution_rights_region")]
+		public string[] DistributionRightsRegion { get; set; }
+
+		[JsonProperty("editorial_reviews")]
+		public string[] EditorialReviews { get; set; }
+
+		[JsonProperty("format_type")]
+		public string FormatType { get; set; }
+
+		[JsonProperty("has_children")]
+		public bool? HasChildren { get; set; }
+
+		[JsonProperty("is_adult_product")]
+		public bool? IsAdultProduct { get; set; }
+
+		[JsonProperty("is_buyable")]
+		public bool? IsBuyable { get; set; }
+
+		[JsonProperty("is_listenable")]
+		public bool? IsListenable { get; set; }
+
+		[JsonProperty("is_preorderable")]
+		public bool? IsPreorderable { get; set; }
+
+		[JsonProperty("is_purchasability_suppressed")]
+		public bool? IsPurchasabilitySuppressed { get; set; }
+
+		[JsonProperty("is_world_rights")]
+		public bool? IsWorldRights { get; set; }
+
+		[JsonProperty("issue_date")]
+		public DateTimeOffset? IssueDate { get; set; }
+
+		[JsonProperty("language")]
+		public string Language { get; set; }
+
+		[JsonProperty("merchandising_summary")]
+		public string MerchandisingSummary { get; set; }
+
+		[JsonProperty("narrators")]
+		public Author[] Narrators { get; set; }
+
+		[JsonProperty("preorder_release_date")]
+		public DateTimeOffset? PreorderReleaseDate { get; set; }
+
+		[JsonProperty("price")]
+		public Price Price { get; set; }
+
+		[JsonProperty("product_images")]
+		public ProductImages ProductImages { get; set; }
+
+		[JsonProperty("publication_datetime")]
+		public DateTimeOffset? PublicationDatetime { get; set; }
+
+		[JsonProperty("publication_name")]
+		public string PublicationName { get; set; }
+
+		[JsonProperty("publisher_name")]
+		public string PublisherName { get; set; }
+
+		[JsonProperty("publisher_summary")]
+		public string PublisherSummary { get; set; }
+
+		[JsonProperty("rating")]
+		public Rating Rating { get; set; }
+
+		[JsonProperty("relationships")]
+		public Relationship[] Relationships { get; set; }
+
+		[JsonProperty("release_date")]
+		public DateTimeOffset? ReleaseDate { get; set; }
+
+		[JsonProperty("runtime_length_min")]
+		public long? RuntimeLengthMin { get; set; }
+
+		[JsonProperty("sample_url")]
+		public Uri SampleUrl { get; set; }
+
+		[JsonProperty("sku")]
+		public string Sku { get; set; }
+
+		[JsonProperty("sku_lite")]
+		public string SkuLite { get; set; }
+
+		[JsonProperty("social_media_images")]
+		public SocialMediaImages SocialMediaImages { get; set; }
+
+		[JsonProperty("subtitle")]
+		public string Subtitle { get; set; }
+
+		[JsonProperty("thesaurus_subject_keywords")]
+		public string[] ThesaurusSubjectKeywords { get; set; }
+
+		[JsonProperty("title")]
+		public string Title { get; set; }
+	}
+
+	public partial class Author
+	{
+		[JsonProperty("asin")]
+		public string Asin { get; set; }
+
+		[JsonProperty("name")]
+		public string Name { get; set; }
+	}
+
+	public partial class CustomerRights
+	{
+		[JsonProperty("is_consumable")]
+		public bool IsConsumable { get; set; }
+
+		[JsonProperty("is_consumable_indefinitely")]
+		public bool IsConsumableIndefinitely { get; set; }
+
+		[JsonProperty("is_consumable_offline")]
+		public bool IsConsumableOffline { get; set; }
+
+		[JsonProperty("is_consumable_until")]
+		public object IsConsumableUntil { get; set; }
+	}
+
+	public partial class SocialMediaImages
+	{
+		[JsonProperty("facebook")]
+		public Uri Facebook { get; set; }
+
+		[JsonProperty("twitter")]
+		public Uri Twitter { get; set; }
+	}
+}

--- a/AudibleApi/Api.WishList.cs
+++ b/AudibleApi/Api.WishList.cs
@@ -1,49 +1,252 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
+using AudibleApi.Common;
 using Dinah.Core;
-using Dinah.Core.Net.Http;
 using Newtonsoft.Json.Linq;
 
 namespace AudibleApi
 {
+	public class WishListOptions
+	{
+		public const int NUMBER_OF_RESULTS_PER_PAGE_MIN = 0;
+		public const int NUMBER_OF_RESULTS_PER_PAGE_MAX = 50;
+
+		private int? _numResults;
+		public int? NumberOfResultPerPage
+		{
+			get => _numResults;
+			set => _numResults
+				= value is null
+				? null
+				: ArgumentValidator.EnsureBetweenInclusive(value.Value, nameof(value), NUMBER_OF_RESULTS_PER_PAGE_MIN, NUMBER_OF_RESULTS_PER_PAGE_MAX);
+		}
+
+		private int? _page;
+		public int? PageNumber
+		{
+			get => _page;
+			set => _page
+				= value is null
+				? null
+				: ArgumentValidator.EnsureGreaterThan(value.Value, nameof(value), -1);
+		}
+
+		[Flags]
+		public enum ResponseGroupOptions
+		{
+			None = 0,
+			[Description("contributors")]
+			Contributors = 1 << 0,
+			[Description("media")]
+			Media = 1 << 1,
+			[Description("price")]
+			Price = 1 << 2,
+			[Description("product_attrs")]
+			ProductAttrs = 1 << 3,
+			[Description("product_desc")]
+			ProductDesc = 1 << 4,
+			[Description("product_extended_attrs")]
+			ProductExtendedAttrs = 1 << 5,
+			[Description("product_plan_details")]
+			ProductPlanDetails = 1 << 6,
+			[Description("product_plans")]
+			ProductPlans = 1 << 7,
+			[Description("rating")]
+			Rating = 1 << 8,
+			[Description("sample")]
+			Sample = 1 << 9,
+			[Description("sku")]
+			Sku = 1 << 10,
+			[Description("customer_rights")]
+			CustomerRights = 1 << 11,
+			[Description("relationships")]
+			Relationships = 1 << 12,
+			ALL_OPTIONS = (1 << 13) - 1
+		}
+
+		public ResponseGroupOptions ResponseGroups { get; set; }
+
+		public enum SortByOptions
+		{
+			None,
+			[Description("-Author")]
+			AuthorDesc,
+			[Description("-DateAdded")]
+			DateAddedDesc,
+			[Description("-Price")]
+			PriceDesc,
+			[Description("-Rating")]
+			RatingDesc,
+			[Description("-Title")]
+			TitleDesc,
+			[Description("Author")]
+			Author,
+			[Description("DateAdded")]
+			DateAdded,
+			[Description("Price")]
+			Price,
+			[Description("Rating")]
+			Rating,
+			[Description("Title")]
+			Title
+		}
+		public SortByOptions SortBy { get; set; }
+
+		public string ToQueryString(Locale locale)
+		{
+			var parameters = new List<string>
+			{
+				"locale=" + locale.Language
+			};
+
+			if (NumberOfResultPerPage.HasValue)
+				parameters.Add("num_results=" + NumberOfResultPerPage.Value);
+
+			if (PageNumber.HasValue)
+				parameters.Add("page=" + PageNumber.Value);
+
+			if (ResponseGroups != ResponseGroupOptions.None)
+				parameters.Add(ResponseGroups.ToResponseGroupsQueryString());
+
+			if (SortBy != SortByOptions.None)
+				parameters.Add(SortBy.ToSortByQueryString());
+
+			if (!parameters.Any())
+				return "";
+
+			return string.Join("&", parameters);
+		}
+	}
 	public partial class Api
 	{
 		const string WISHLIST_PATH = "/1.0/wishlist";
 
-		public async Task<bool> IsInWishListAsync(string asin)
+		public async Task<List<Product>> GetWishListProductsAsync(WishListOptions wishlistOptions, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
 		{
-			ArgumentValidator.EnsureNotNullOrWhiteSpace(asin, nameof(asin));
+			using var semaphoreSlim = new SemaphoreSlim(maxConcurrentRequests);
 
-			// test with page results = 10. for production => 50
-			var num_results = 50;
+			return await GetWishListProductsAsync(wishlistOptions, numItemsPerRequest, semaphoreSlim);
+		}
 
-			// pages are 0 indexed
-			var page = 0;
-			var accum = 0;
-			int total_results;
+		public async Task<List<Product>> GetWishListProductsAsync(WishListOptions wishlistOptions, int numItemsPerRequest, SemaphoreSlim semaphore)
+		{
+			var allItems = new List<Product>();
 
-			// iterate through all pages
+			await foreach (var items in GetWishListPagesAsync(wishlistOptions, numItemsPerRequest, semaphore))
+				allItems.AddRange(items);
+
+			return allItems;
+		}
+
+		public async IAsyncEnumerable<Product> GetWishListProductsAsyncEnumerable(WishListOptions wishlistOptions, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+		{
+			await foreach (var page in GetWishListPagesAsync(wishlistOptions, numItemsPerRequest, maxConcurrentRequests))
+				foreach (var item in page)
+					yield return item;
+		}
+
+		public async IAsyncEnumerable<Product> GetWishListProductsAsyncEnumerable(WishListOptions wishlistOptions, int numItemsPerRequest, SemaphoreSlim semaphore)
+		{
+			await foreach (var page in GetWishListPagesAsync(wishlistOptions, numItemsPerRequest, semaphore))
+				foreach (var item in page)
+					yield return item;
+		}
+
+		public async IAsyncEnumerable<Product[]> GetWishListPagesAsync(WishListOptions wishlistOptions, int numItemsPerRequest = 50, int maxConcurrentRequests = 10)
+		{
+			using var semaphore = new SemaphoreSlim(maxConcurrentRequests);
+
+			await foreach (var item in GetWishListPagesAsync(wishlistOptions, numItemsPerRequest, semaphore))
+				yield return item;
+		}
+
+		public async IAsyncEnumerable<Product[]> GetWishListPagesAsync(WishListOptions wishlistOptions, int numItemsPerRequest, SemaphoreSlim semaphore)
+		{
+			ArgumentValidator.EnsureNotNull(wishlistOptions, nameof(wishlistOptions));
+			ArgumentValidator.EnsureNotNull(semaphore, nameof(semaphore));
+
+			wishlistOptions.NumberOfResultPerPage = ArgumentValidator.EnsureBetweenInclusive(
+				numItemsPerRequest,
+				nameof(numItemsPerRequest),
+				WishListOptions.NUMBER_OF_RESULTS_PER_PAGE_MIN,
+				WishListOptions.NUMBER_OF_RESULTS_PER_PAGE_MAX);
+
+			List<Task<WishListDtoV10>> pageDlTasks = new();
+
+			int page = 0;
+			int totalItems = await GetWishListItemsCountAsync(wishlistOptions);
+			int totalPages = totalItems / numItemsPerRequest;
+			if (totalPages * numItemsPerRequest < totalItems) totalPages++;
+
+			//Spin up as many concurrent downloads as we can/need. Minimum 1.
 			do
+				await spinupPageRequestAsync();
+			while (semaphore.CurrentCount > 0 && page < totalPages);
+
+			while (pageDlTasks.Count > 0)
 			{
-				var url = $"{WISHLIST_PATH}?num_results={num_results}&page={page}&sort_by=-DateAdded";
-				var response = await AdHocAuthenticatedGetAsync(url);
-				var obj = await response.Content.ReadAsJObjectAsync();
+				var completed = await Task.WhenAny(pageDlTasks);
+				pageDlTasks.Remove(completed);
 
-				var products = obj["products"] as JArray;
+				//Request new page(s)
+				while (semaphore.CurrentCount > 0 && page < totalPages)
+					await spinupPageRequestAsync();
 
-				page++;
-				accum += products.Count;
-				total_results = (int)obj["total_results"];
-
-				if (products.Any(p => p.Value<string>("asin") == asin))
-					return true;
+				yield return completed.Result.Products;
 			}
-			while (accum < total_results);
 
-			return false;
+			async Task spinupPageRequestAsync()
+			{
+				wishlistOptions.PageNumber = page;
+				await semaphore.WaitAsync();
+				pageDlTasks.Add(getWishListPageAsync(semaphore, wishlistOptions.ToQueryString(Locale), page));
+				page++;
+			}
+		}
+
+		private async Task<WishListDtoV10> getWishListPageAsync(SemaphoreSlim semaphore, string queryString, int pageNumber)
+		{
+			try
+			{
+				var url = $"{WISHLIST_PATH}?{queryString}";
+				var response = await AdHocAuthenticatedGetAsync(url);
+
+				var libResult = await response.Content.ReadAsDtoAsync<WishListDtoV10>();
+
+				Serilog.Log.Logger.Information($"Page {pageNumber}: {libResult.Products.Length} results");
+				return libResult;
+			}
+			finally { semaphore?.Release(); }
+		}
+
+
+		/// <summary>Gets the total number of Items in the account's wish list</summary>
+		public async Task<int> GetWishListItemsCountAsync(WishListOptions wishlistOptions)
+		{
+			var orig = wishlistOptions.NumberOfResultPerPage;
+
+			try
+			{
+				wishlistOptions.PageNumber = 0;
+				wishlistOptions.NumberOfResultPerPage = 0;
+
+				var url = $"{WISHLIST_PATH}?{wishlistOptions.ToQueryString(Locale)}";
+				var response = await AdHocAuthenticatedGetAsync(url);
+
+				var dto = await response.Content.ReadAsDtoAsync<WishListDtoV10>();
+
+				return dto.TotalResults;
+			}
+			finally
+			{
+				wishlistOptions.NumberOfResultPerPage = orig;
+			}
 		}
 
 		public async Task AddToWishListAsync(string asin)

--- a/AudibleApi/EzApiCreator/EzApiCreator.LoginChoiceEager.cs
+++ b/AudibleApi/EzApiCreator/EzApiCreator.LoginChoiceEager.cs
@@ -44,7 +44,7 @@ namespace AudibleApi
 			if (choiceOut is null)
 			{
 				// TODO: exceptions should not be used for control flow. fix this
-				throw new Exception("Login attempt cancelled by user");
+				throw new OperationCanceledException("Login attempt cancelled by user");
 			}
 
 			return choiceOut.LoginMethod switch

--- a/_Tests/AudibleApi.Tests/L0/Authorization/IdentityTests.cs
+++ b/_Tests/AudibleApi.Tests/L0/Authorization/IdentityTests.cs
@@ -51,10 +51,6 @@ namespace Authoriz.IdentityTests
 				Locale.Empty,
 				null,
 				new List<KeyValuePair<string, string>>()));
-			Assert.ThrowsException<ArgumentNullException>(() => new Identity(
-				Locale.Empty,
-				OAuth2.Empty,
-				null));
 		}
 
 		[TestMethod]


### PR DESCRIPTION
[Add WishList methods](https://github.com/rmcrackan/AudibleApi/pull/43/commits/b5cf43bedec6fb3c708268dbf894ab16d5ffc2a6)
Expanded the wishlist api. It now behaves more like Library, where multiples pages are queries concurrently.

[Identify user cancelled login exception](https://github.com/rmcrackan/AudibleApi/pull/43/commits/61278566635673feb16cf75ade3468b34308a1c5)
If login is cancelled, throw OperationCancelledException. It doesn't fix the problem, but it's better bandaid because we can identify the cancellation and not throw the exception in Libation.