### PR TITLE
Log response bodies as information

### DIFF
--- a/AudibleApi/Authentication/LoginResult.cs
+++ b/AudibleApi/Authentication/LoginResult.cs
@@ -19,7 +19,7 @@ namespace AudibleApi.Authentication
 		public IDictionary<string, string> GetInputsReadOnly()
             => new Dictionary<string, string>(Inputs);
 
-        protected string ResponseBody { get; }
+        public string ResponseBody { get; }
 
         protected LoginResult(Authenticate authenticate, string responseBody)
         {

--- a/AudibleApi/Authentication/LoginResultRunner.cs
+++ b/AudibleApi/Authentication/LoginResultRunner.cs
@@ -176,11 +176,7 @@ namespace AudibleApi.Authentication
 						Serilog.Log.Logger.Verbose("ResponseInputFields: {@DebugInfo}", responseInputs);
 
 						// save page content
-						var filename = $"Verbose_ResponseBody_{DateTime.Now.Ticks}.tmp";
-						var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Libation", "Verbose");
-						System.IO.Directory.CreateDirectory(tempDir);
-						var path = System.IO.Path.Combine(tempDir, filename);
-						System.IO.File.WriteAllText(path, body);
+						Serilog.Log.Logger.Verbose("{@responsebody}", new { filename = "Verbose_ResponseBody.html", filedata = System.Text.Encoding.UTF8.GetBytes(body) });
 					}
 				}
 				catch (Exception ex)

--- a/AudibleApi/Authentication/LoginResultRunner.cs
+++ b/AudibleApi/Authentication/LoginResultRunner.cs
@@ -177,7 +177,9 @@ namespace AudibleApi.Authentication
 
 						// save page content
 						var filename = $"Verbose_ResponseBody_{DateTime.Now.Ticks}.tmp";
-						var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Libation", "Verbose", filename);
+						var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Libation", "Verbose");
+						System.IO.Directory.CreateDirectory(tempDir);
+						var path = System.IO.Path.Combine(tempDir, filename);
 						System.IO.File.WriteAllText(path, body);
 					}
 				}

--- a/AudibleApi/EzApiCreator/EzApiCreator.LoginCallback.cs
+++ b/AudibleApi/EzApiCreator/EzApiCreator.LoginCallback.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using AudibleApi.Authentication;
 using AudibleApi.Authorization;
+using Dinah.Core;
 
 namespace AudibleApi
 {
@@ -52,6 +53,18 @@ namespace AudibleApi
 			while (true)
 			{
 				Serilog.Log.Logger.Information("Login result: {@DebugInfo}", loginResult.GetType());
+
+				{
+					//Compress and log the response body
+					var utf8Bts = System.Text.Encoding.UTF8.GetBytes(loginResult.ResponseBody.Replace(email, email.ToMask()));
+					var compressSz = System.IO.Compression.BrotliEncoder.GetMaxCompressedLength(utf8Bts.Length);
+					var compressedBts = new byte[compressSz];
+
+					if (System.IO.Compression.BrotliEncoder.TryCompress(utf8Bts, compressedBts, out compressSz, 11, 24))
+						Serilog.Log.Logger.Information("ResponseBody: {content}", Convert.ToBase64String(compressedBts, 0, compressSz));
+					else
+						Serilog.Log.Logger.Error("Failed to compress response body");
+				}
 
 				switch (loginResult)
 				{

--- a/AudibleApi/EzApiCreator/EzApiCreator.LoginCallback.cs
+++ b/AudibleApi/EzApiCreator/EzApiCreator.LoginCallback.cs
@@ -52,18 +52,18 @@ namespace AudibleApi
 
 			while (true)
 			{
-				Serilog.Log.Logger.Information("Login result: {@DebugInfo}", loginResult.GetType());
-
 				{
-					//Compress and log the response body
-					var utf8Bts = System.Text.Encoding.UTF8.GetBytes(loginResult.ResponseBody.Replace(email, email.ToMask()));
-					var compressSz = System.IO.Compression.BrotliEncoder.GetMaxCompressedLength(utf8Bts.Length);
-					var compressedBts = new byte[compressSz];
+					//log the response body
+					var resultType = loginResult.GetType();
 
-					if (System.IO.Compression.BrotliEncoder.TryCompress(utf8Bts, compressedBts, out compressSz, 11, 24))
-						Serilog.Log.Logger.Information("ResponseBody: {content}", Convert.ToBase64String(compressedBts, 0, compressSz));
-					else
-						Serilog.Log.Logger.Error("Failed to compress response body");
+					Serilog.Log.Logger.Information("Login result: {@DebugInfo}", resultType);
+					Serilog.Log.Logger.Information("{@logfile}",
+						new
+						{
+							filename = $"{resultType}.html",
+							System.IO.Compression.CompressionLevel.Fastest,
+							filedata = System.Text.Encoding.UTF8.GetBytes(loginResult.ResponseBody.Replace(email, email.ToMask()))
+						});
 				}
 
 				switch (loginResult)


### PR DESCRIPTION
I'm leaving this as draft until I get your feedback on [Create directory before attempting to write file](https://github.com/rmcrackan/AudibleApi/commit/6f054b890d92adcadd08f4146173f6f01e7df15e).

As you'd previously pointed out, AudibleApi is supposed to be useful to anyone not just Libation. But the verbose file logging logs to a Libation directory. Do you care?