### PR TITLE
Fall back to aax workaround if failed to get aaxc content license

### DIFF
--- a/AudibleApi/Api.Download.cs
+++ b/AudibleApi/Api.Download.cs
@@ -3,6 +3,8 @@ using Dinah.Core;
 using Dinah.Core.Net.Http;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -56,9 +58,34 @@ namespace AudibleApi
             }
             catch (ApiErrorException ex)
             {
-                //Assume this exception will not contain PII.
-                Serilog.Log.Logger.Error(ex, "Error getting download license");
-                throw;
+				//Assume this exception will not contain PII.
+				Serilog.Log.Logger.Error(ex, "Error getting download license. Try aax workaround.");
+				try
+                {
+                    //This book doesn't exist as an aaxc. Fall back to old AAX workaround method and try again.
+                    var url = await DownloadAaxWorkaroundAsync(asin);
+                    
+                    var contentLic = new ContentLicense
+                    {
+                        DrmType = DrmType.Adrm,
+                        Asin = asin,
+                        ContentMetadata = await GetContentMetadataAsync(asin, chapterTitlesType),
+                        Voucher = new VoucherDtoV10
+                        {
+                            Key = await GetActivationBytesAsync(),
+                        }
+                    };
+
+					contentLic.ContentMetadata.ContentUrl = new ContentUrl { OfflineUrl = url };
+
+					return contentLic;
+                }
+                catch (Exception ex2)
+                {
+					//Assume this exception will not contain PII.
+					Serilog.Log.Logger.Error(ex2, "Error getting download license");
+					throw;
+				}
             }
             catch (Exception ex)
             {
@@ -141,8 +168,85 @@ namespace AudibleApi
             return contentLicenseDtoV10.ContentLicense;
         }
 
-        #endregion
+		#endregion
 
-        public async Task<string> GetPdfDownloadLinkAsync(string asin) => (await GetDownloadLicenseAsync(asin)).PdfUrl;
+        private static readonly string[] CodecPreferenceOrder = new[] { EnhancedCodec.Lc128_44100_Stereo, EnhancedCodec.Lc64_44100_Stereo, EnhancedCodec.Lc64_22050_Stereo, EnhancedCodec.Lc32_22050_Stereo, EnhancedCodec.Aax, EnhancedCodec.Mp444128, EnhancedCodec.Mp44464, EnhancedCodec.Mp42264, EnhancedCodec.Mp42232, EnhancedCodec.Piff44128, EnhancedCodec.Piff4464, EnhancedCodec.Piff2232, EnhancedCodec.Piff2264 };
+
+		/// <summary>
+		/// download aax book file.
+		/// note that this is always a single-file download, even with normally multi-part books
+		/// 
+		/// this is the 'aax workaround' to the AAXC problem
+		/// https://github.com/mkb79/Audible/issues/3
+		/// </summary>
+		/// <returns>Filename of downloaded file</returns>
+		public async Task<string> DownloadAaxWorkaroundAsync(string asin)
+		{
+			#region // downloading via cds.audible.com
+			// there are probably other options to play with later.
+			// here's what i'd previously scraped from the library page:
+			// https://cds.audible.com/download/admhelper?user_id=xsIBLaVXKZWXlo5Azn5OfKIpHO_aES2Obo0Pq4JbIyJgzpJB7vpW-_GtV7_a&product_id=BK_TANT_004502&domain=www.audible.com&cust_id=xsIBLaVXKZWXlo5Azn5OfKIpHO_aES2Obo0Pq4JbIyJgzpJB7vpW-_GtV7_a&DownloadType=Now&transfer_player=1&codec=LC_64_22050_Stereo&awtype=AAX&title=The Utterly Uninteresting and Unadventurous Tales of Fred, the Vampire Accountant
+			// here's what the other api makers discovered as their aax workaround around the aaxc issue:
+			// https://cds.audible.com/download?asin=B06WLMWF2S&cust_id=zLKehcc-_2JBt-P-KqVn4VoWpfv3fqLyDVJ5SBPqXD1lCzjHSSzHBtW1I2wd&codec=LC_64_22050_stereo&source=audible_iPhone&type=AUDI
+			#endregion
+
+			ArgumentValidator.EnsureNotNullOrWhiteSpace(asin, nameof(asin));
+
+			var allCodecs = await getAllCodecsAsync(asin);
+			// since Intersect() doesn't guarantee order, do not use it here
+			var codec = CodecPreferenceOrder.FirstOrDefault(allCodecs.Contains) ?? allCodecs[0];
+
+			// note: remainder of this method requires a DIFFERENT client
+			var client = Sharer.GetSharedHttpClient("https://cde-ta-g7g.amazon.com");
+
+			var requestUri = $"/FionaCDEServiceEngine/FSDownloadContent?type=AUDI&currentTransportMethod=WIFI&key={asin}&codec={codec}";
+			var response = await AdHocAuthenticatedGetAsync(requestUri, client);
+			if (response.StatusCode != HttpStatusCode.Found)
+				throw new Exception("Incorrect response code");
+			var downloadUrl = response.Headers.Location.AbsoluteUri;
+
+			// localize download link
+			var cdsRoot = "https://cds.audible.";
+			downloadUrl = downloadUrl.Replace(
+				$"{cdsRoot}com",
+				$"{cdsRoot}{Locale.TopDomain}");
+
+			return downloadUrl;
+		}
+
+		private async Task<List<string>> getAllCodecsAsync(string asin)
+		{
+			const int maxAttempts = 2;
+
+			string bookJson;
+
+			var libraryOptions = LibraryOptions.ResponseGroupOptions.ProductAttrs | LibraryOptions.ResponseGroupOptions.Relationships;
+
+			var currAttempt = 0;
+			do
+			{
+				currAttempt++;
+
+				var bookJObj = await GetLibraryBookAsync(asin, libraryOptions);
+				bookJson = bookJObj.ToString();
+				var availableCodecs = bookJObj?.AvailableCodecs;
+				var codecs = availableCodecs?
+					.Where(ac => !string.IsNullOrWhiteSpace(ac.EnhancedCodec))
+					.Select(ac => ac.EnhancedCodec)
+					.ToList();
+
+				if (codecs is not null && codecs.Any())
+					return codecs;
+
+				// if no codec, try once more with all options enbled
+				libraryOptions = LibraryOptions.ResponseGroupOptions.ALL_OPTIONS;
+			}
+			while (currAttempt < maxAttempts);
+
+			// if still no codec: error
+			throw new ApplicationException("Book has no codec specified. Cannot continue with download. Full book data:\r\n" + bookJson);
+		}
+
+		public async Task<string> GetPdfDownloadLinkAsync(string asin) => (await GetDownloadLicenseAsync(asin)).PdfUrl;
     }
 }


### PR DESCRIPTION
This is a fix for https://github.com/rmcrackan/Libation/issues/586

I've never seen this before, but that particular book is only downloadable as widevine or as an aax file. Resurrected the aax workaround and use it as a fallback if the primary method fails.