### PR TITLE
Add asset_details type and property to book Item Dto

### DIFF
--- a/AudibleApi.Common/LibraryDtoV10.cs
+++ b/AudibleApi.Common/LibraryDtoV10.cs
@@ -32,6 +32,11 @@ namespace AudibleApi.Common
 		public override string ToString() => $"{Items?.Length ?? 0} {nameof(Items)}, {ResponseGroups?.Length ?? 0} {nameof(ResponseGroups)}";
 	}
 
+	public partial class AssetDetail
+	{
+		public override string ToString() => IsSpatial ? $"{Name} (spatial)" : $"{Name}";
+	}
+
 	public partial class Person
 	{
 		public override string ToString() => $"{Name}";

--- a/AudibleApi.Common/LibraryDtoV10.generated.cs
+++ b/AudibleApi.Common/LibraryDtoV10.generated.cs
@@ -24,6 +24,9 @@ namespace AudibleApi.Common
         [JsonProperty("asin")]
         public string Asin { get; set; }
 
+        [JsonProperty("asset_details")]
+        public AssetDetail[] AssetDetails { get; set; }
+
         [JsonProperty("audible_editors_summary")]
         public string AudibleEditorsSummary { get; set; }
 
@@ -305,6 +308,15 @@ namespace AudibleApi.Common
 
 		[JsonProperty("ws4v_companion_asin")]
 		public object Ws4VCompanionAsin { get; set; }
+	}
+
+	public partial class AssetDetail
+	{
+		[JsonProperty("is_spatial")]
+		public bool IsSpatial { get; set; }
+
+		[JsonProperty("name")]
+		public string Name { get; set; }
 	}
 
 	public partial class Person


### PR DESCRIPTION
This is required for feature [rmcrackan/Libation/#1273](https://github.com/rmcrackan/Libation/issues/1273)
As far as I can tell, this is the only field which tells you if the book supports spatial audio.